### PR TITLE
create a default "setI18n" method on the instance class.

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -358,7 +358,9 @@
 
             // set a locale to an instance on the default "_i18n" attribute
             _setI18n: function (event, data) {
-                this._i18n = data && data.locale;
+                if ((this._i18n = data && data.i18n)) {
+                    doc.cookie = 'i18n=' + this._i18n;
+                }
             }
         },
 

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -359,7 +359,7 @@
             // set a locale to an instance on the default "_i18n" attribute
             _setI18n: function (event, data) {
                 data = typeof data === "string" ? { i18n: data } : data;
-                this._i18n = data && data.i18n;
+                Z._i18n = data && data.i18n;
             }
         },
 

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -354,6 +354,11 @@
 
                 // load root instance
                 Z._load();
+            },
+
+            // set a locale to an instance on the default "_i18n" attribute
+            _setI18n: function (event, data) {
+                this._i18n = data && data.locale;
             }
         },
 

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -354,12 +354,6 @@
 
                 // load root instance
                 Z._load();
-            },
-
-            // set a locale to an instance on the default "_i18n" attribute
-            _setI18n: function (event, data) {
-                data = typeof data === "string" ? { i18n: data } : data;
-                Z._i18n = data && data.i18n;
             }
         },
 
@@ -552,6 +546,9 @@
     coreInstance.on('I>', send('I>'));
     coreInstance.on('V>', send('V>'));
     coreInstance.on('M>', send('M>'));
+
+    // i18n
+    coreInstance._i18n = null;
 
     // core module methods
     coreInstance.wrap = function (path, module) {

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -358,9 +358,8 @@
 
             // set a locale to an instance on the default "_i18n" attribute
             _setI18n: function (event, data) {
-                if ((this._i18n = data && data.i18n)) {
-                    doc.cookie = 'i18n=' + this._i18n;
-                }
+                data = typeof data === "string" ? { i18n: data } : data;
+                this._i18n = data && data.i18n;
             }
         },
 


### PR DESCRIPTION
The `self._setI18n` method just sets the given value to a default `self._i18n` property.
This gives modules the ability to have a standard interface to set and get a locale.
