### PR TITLE
Instance name aliases

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -205,7 +205,7 @@
                 var self = this;
                 var factory = factories[type];
                 var clone;
-                var cacheKey;
+                var cacheKey = name;
                 var typeName = type === 'I' ? 'inst' : type === 'V' ? 'view' : type === 'M' ? 'model' : null;
 
                 // ensure callback
@@ -216,9 +216,6 @@
                     // TODO how to set the elements name?
                     return loader.call(self, factory, self._clone(classes[type]), name, callback, sub);
                 }
-
-                // create cache key
-                cacheKey = name instanceof Array ? name.join() : name;
 
                 // views are only unique with instance name
                 if (type === 'V') {
@@ -250,6 +247,16 @@
 
                     // set instance scope to new clone
                     if (type === 'I') {
+
+                        if (config.name) {
+
+                            // update instance name
+                            clone._name = config.name;
+
+                            // also save instance under the original name in cache
+                            cache[type][config.name] = clone;
+                        }
+
                         self = clone;
                     }
 

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -95,12 +95,12 @@ function linkHandler (link) {
                 link.call = pathValue(link.call, self);
             }
 
-            link.call.call(self, err, data, sendHandler(self._sendName, self));
+            link.call.call(self, err, data, sendHandler(self._name, self));
         }
 
         // emit event
         if (link.emit) {
-            self.emit(link.emit, err, data, sendHandler(self._sendName, self));
+            self.emit(link.emit, err, data, sendHandler(self._name, self));
         }
     });
 
@@ -135,7 +135,6 @@ function instanceFactory (name, module, compInst, callback) {
     instance._access = {};
     instance._roles = compInst.roles || {};
     instance._client = {};
-    instance._sendName = name;
 
     // save configs on instance
     if (compInst.config) {
@@ -207,6 +206,14 @@ function instanceFactory (name, module, compInst, callback) {
 
     // attach the broadcast functionality
     instance._broadcast = broadcast;
+
+    // send original instance name to client, in case it's an alias
+    if (compInst.name !== name) {
+        instance._client.name = compInst.name;
+
+        // save instance also under original name
+        pojoInstances.set(compInst.name, instance);
+    }
 
     // save instance in cache
     // TODO update this cache when a instance config changes
@@ -291,12 +298,10 @@ function load (err, instance, callback) {
     // handle no access case
     if (cachedInstance === 0) {
         return callback('Instance: ' + instance + '. Error: Instance not found.');
-        //self.emit(env.Z_SEND_INST_RES, 'Instance: ' + instance + '. Error: Instance not found.');
     }
 
     if (cachedInstance) {
         return callback(null, cachedInstance._client);
-        //self.emit(env.Z_SEND_INST_RES, null, cachedInstance._client);
     }
 
     // load and init module
@@ -304,12 +309,10 @@ function load (err, instance, callback) {
 
         if (err) {
             return callback('Instance: ' + instance + '. Error: ' + err);
-            //self.emit(env.Z_SEND_INST_RES, 'Instance: ' + instance + '. Error: ' + err);
         }
 
         // return client config
         callback(null, client);
-        //self.emit(env.Z_SEND_INST_RES, null, client);
     });
 }
 


### PR DESCRIPTION
Now, an instance can have multiple name aliases, but in the composition they are configurable with the original name. fixes #8.
