### PR TITLE
More consistent url to data parsing

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -759,7 +759,6 @@
     // act (handlers)
     function act (config, dom, elmIndex, elms, dontPrevent) {
         var _self = this;
-        var test_tmpl = /^{.+}$/;
         var find_tmpl = /{([\w\.]+)}/g;
         var find_braces = /\{|\}/g;
         var find_index = /\.\$(?=\.|$)/g;
@@ -817,6 +816,7 @@
                 var key;
                 var data;
                 var to;
+                var _path;
 
                 for (i = 0; i < config.emit.length; ++i) {
 
@@ -855,24 +855,10 @@
                     // add dynamic data to the data object
                     if (emit.add) {
 
-                        // split pathname to an array
-                        var url_path = win_location.pathname.substr(1).split('/');
-
                         // add data to the data object
                         for (key in emit.add) {
-
-                            // handle url pathname
-                            if (parseInt(key, 10) > -1 && url_path[key] !== undefined) {
-
-                                // extend data object with pathname value
-                                data[emit.add[key]] = url_path[key];
-
-                            // handle method path string
-                            } else {
-
-                                // extend data object with data from path
-                                data[key] = self._path(emit.add[key].replace(find_index, '.' + (elmIndex || 0)));
-                            }
+                            _path = emit.add[key].replace(find_index, '.' + (elmIndex || 0));
+                            data[key] = self._path(_path) || self._path(_path, data, true);
                         }
                     }
 


### PR DESCRIPTION
The URL is now accessible in the data object:

``` json
{
    "_path": ["my", "url", "path"],
    "_search": {
        "key": "value"
    },
    "_hash": "value"
}
```

This allows following `add` configurations:

``` json
{
    "pathKey": "_path.3",
    "searchKey": "_search.key",
    "hashKey": "_hash"
}
```
