### PR TITLE
Updated render method

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -931,7 +931,7 @@
         if (!dont_escape_html) {
             return str.replace(/[&\"<>]/g, function(char) {
                 return render_escape[char];
-            });:
+            });
         }
 
         return str;

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -395,11 +395,12 @@
         V: {
 
             // render data to the html template
-            render: function (data, leaveKeys, dontAppend) {
+            render: function (data, dontEscape, leaveKeys, dontAppend) {
                 var self = this;
+                var escape_fn;
 
                 // check if a template exists
-                if (!self._tp) {
+                if (!self.tpl) {
                     return;
                 }
 
@@ -414,7 +415,8 @@
                         rData = self.on.data.call(self, data[i]) || data[i];
                     }
 
-                    self.html += self._tp(rData || data[i] || {}, leaveKeys, self._);
+                    // render
+                    self.html += self.tpl(rData || data[i], default_escape_fn, dontEscape || self.dontEscape, leaveKeys || self.leaveKeys);
                 }
 
                 // change html before writing it to the dom
@@ -426,7 +428,7 @@
                     self.dom = (self.scope || document).querySelector(self.dom);
                 }
 
-                // write html to dom
+                // append html to dom
                 if (!dontAppend && self.dom) {
                     self.dom.innerHTML = self.html;
                 }
@@ -440,14 +442,14 @@
                 if (typeof self.on.done === 'function') {
                     self.on.done(self);
                 }
-
-                return self;
             },
 
             // set a template function or a html snippet
-            set: function (template, dom, scope) {
+            set: function (html, dom, scope) {
                 var self = this;
-                self._tp = typeof template === 'function' ? template : createTemplate(template);
+
+                // create template function
+                self.tpl = createTemplate(html);
                 self.scope = scope;
                 self.dom = dom;
             }
@@ -466,15 +468,11 @@
                     d: data
                 }, function (err, data) {
 
-                    if (err) {
-                        return callback(err);
-                    }
-
                     // save current data
                     self.data = data;
 
-                    // callback or emit data
-                    callback ? callback(null, data) : self._.emit('m_' + self._name + '_data');
+                    // callback
+                    callback(err, data);
                 });
             }
         }
@@ -515,9 +513,14 @@
             // save config on view instance
             view.config = config.config || {};
 
-            // handlers
-            view.on = {};
+            // dont escape html default config
+            view.dontEscape = config.dontEscape;
+
+            // leave keys in template default config
+            view.leaveKeys = config.leaveKeys;
+
             // append custom handlers
+            view.on = {};
             if (config.on) {
                 for (var event in config.on) {
                     view.on[event] = self._path(config.on[event]);
@@ -528,15 +531,6 @@
             if (config.html) {
                 view.set(config.html, config.to, config['in']);
             }
-
-            // TODO update view on model data
-            /*if (config.L) {
-                for (var i = 0; i < config.L.length; ++i) {
-                    if (config.L[i].type === 'M') {
-                        self.on('m_' + config.L[i].name + '_data', view.render);
-                    }
-                }
-            }*/
 
             // save observer action config for later use after rendering
             if (config.O && config.O.actions) {
@@ -549,6 +543,7 @@
 
         // model
         // TODO add an option for live updates (push)
+        // TODO update a connected view on live update
         M: function (model, config) {
             var self = this;
 
@@ -563,6 +558,11 @@
             self.model[config.name] = model;
         }
     };
+
+    // ---------------------------------------------------------- VIEW CONSTANTS
+
+    var template_escape = {"\\": "\\\\", "\n": "\\n", "\r": "\\r", "'": "\\'"};
+    var render_escape = {'&': '&amp;', '"': '&quot;', '<': '&lt;', '>': '&gt;'};
 
     // ----------------------------------------------------------- CORE INSTANCE
 
@@ -918,22 +918,32 @@
 
     // ---------------------------------------------------------- VIEW FUNCTIONS
 
+    // escape html chars
+    function default_escape_fn (data, key, dont_escape_html, leaveKeys) {
+
+        // get the string value
+        str = key.indexOf('.') > 0 ? Z._path(key, data) : data[key];
+
+        // if str is null or undefined
+        str = (str == null ? (leaveKeys ? key : '') : str) + '';
+
+        // escape html chars
+        if (!dont_escape_html) {
+            return str.replace(/[&\"<>]/g, function(char) {
+                return render_escape[char];
+            });:
+        }
+
+        return str;
+    }
+
     // create a template function
-    function createTemplate (html) {
-
-        // TODO update with new riotjs renderer
-        // create template
-        // credentials: http://github.com/muut/riotjs/
-        html = html.replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/'/g, "\\'");
-        html = new Function('d','k','i',
-            "var v;return '" + html.replace(/\{\s*([\w\.]+)\s*\}/g, "'+("+
-            "(v='$1'.indexOf('.')>0?i._path('$1',d):d['$1'])?(v+'')" +
-            ".replace(/&/g,'&amp;')" +
-            ".replace(/'/g,'&quot;')" +
-            ":v===0?0:(k?'{$1}':''))+'") + "'"
+    function createTemplate (tmpl) {
+        return new Function("_", "f", "e", "k", "_=_||{};return '" +
+            (tmpl || '').replace(/[\\\n\r']/g, function(char) {
+                return template_escape[char];
+            }).replace(/{\s*([\w\.]+)\s*}/g, "' + f(_,'$1',e,k) + '") + "'"
         );
-
-        return html;
     }
 
     // load css files

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -938,6 +938,7 @@
     }
 
     // create a template function
+    // heavily inspired by the https://github.com/muut/riotjs render method
     function createTemplate (tmpl) {
         return new Function("_", "f", "e", "k", "_=_||{};return '" +
             (tmpl || '').replace(/[\\\n\r']/g, function(char) {

--- a/lib/views/factory.js
+++ b/lib/views/factory.js
@@ -114,6 +114,14 @@ function factoryService (err, name, callback) {
             clientView.css = view.css;
         }
 
+        if (view.dontEscape) {
+            clientView.dontEscape = view.dontEscape;
+        }
+
+        if (view.leaveKeys) {
+            clientView.leaveKeys = view.leaveKeys;
+        }
+
         callback(null, clientView);
     });
 }


### PR DESCRIPTION
New we have two options we can configure in a view the composition:

``` json
{
    "dontEscape": false,
    "leaveKeys": false
}
```

`dontEscape` means that `html` chars are not escape. Handy if you want to render `html` into the template.
`leaveKeys` means that the template keys are not removed, when they not found inside the `data` object. Handy if you want to render the template multiple times with different data.

Also the raw `html` is accessible in the `self.view[viewName].html`. But only AFTER the `render` function is called. In case you don't want to append the `html` to the DOM, just call the `render` method with the `dontAppend` true option. Example:

``` js
// the render function takes four arguments: (data, dontEscape, leaveKeys, dontAppend)
self.view.myView.render(null, false, true, true);
```

Fixes #53 and #21 
