### PR TITLE
Append the order of view elements form the composition config to an instance

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -427,7 +427,7 @@
                 }
 
                 if (typeof self.dom === 'string') {
-                    self.dom = (self.scope || document).querySelector(self.dom);
+                    self.dom = (self.scope || doc).querySelector(self.dom);
                 }
 
                 // append html to dom
@@ -503,7 +503,7 @@
         },
 
         // view
-        V: function (view, config) {
+        V: function (view, config, index) {
             var self = this;
 
             // load css files
@@ -541,6 +541,9 @@
 
             // save view in instance
             self.view[config.name] = view;
+
+            // save render order on instance
+            (self._renderOrder = self._renderOrder || [])[index] = config.name;
         },
 
         // model
@@ -684,7 +687,7 @@
         };
 
         // factory clone
-        factory && factory.call(self, clone, config);
+        factory && factory.call(self, clone, config, sub - 1);
 
         // load resources
         if (config.L) {
@@ -696,8 +699,15 @@
                 elements += config.L.elms.length;
 
                 // load sub elements
-                for (var i = 0; i < config.L.elms.length; ++i) {
-                    self._load(config.L.elms[i].type, config.L.elms[i].name, loaderHandler, true);
+                for (var i = 0, elm, vi = 1; i < config.L.elms.length; ++i) {
+                    elm = config.L.elms[i];
+
+                    self._load(elm.type, elm.name, loaderHandler, vi);
+
+                    // increment render order index
+                    if (elm.type == 'V') {
+                        ++vi;
+                    }
                 }
             }
 
@@ -737,7 +747,7 @@
         // actions (dom)
         if (config.actions) {
             for (i = 0; i < config.actions.length; ++i) {
-                elm = document.querySelectorAll(config.actions[i].selector);
+                elm = doc.querySelectorAll(config.actions[i].selector);
                 if (elm) {
                     for (e = 0; e < elm.length; ++e) {
                         elm[e].addEventListener(
@@ -920,8 +930,8 @@
 
         // escape html chars
         if (!dont_escape_html) {
-            return str.replace(/[&\"<>]/g, function(char) {
-                return render_escape[char];
+            return str.replace(/[&\"<>]/g, function(_char) {
+                return render_escape[_char];
             });
         }
 
@@ -932,8 +942,8 @@
     // heavily inspired by the https://github.com/muut/riotjs render method
     function createTemplate (tmpl) {
         return new Function("_", "f", "e", "k", "_=_||{};return '" +
-            (tmpl || '').replace(/[\\\n\r']/g, function(char) {
-                return template_escape[char];
+            (tmpl || '').replace(/[\\\n\r']/g, function(_char) {
+                return template_escape[_char];
             }).replace(/{\s*([\w\.]+)\s*}/g, "' + f(_,'$1',e,k) + '") + "'"
         );
     }
@@ -948,10 +958,10 @@
                 if (!css[urls[i]]) {
                     css[urls[i]] = 1;
 
-                    var link = document.createElement('link');
+                    var link = doc.createElement('link');
                     link.setAttribute('rel', 'stylesheet');
                     link.setAttribute('href', urls[i]);
-                    document.head.appendChild(link);
+                    doc.head.appendChild(link);
                 }
             }
         }

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -230,7 +230,7 @@
 
             // load and set up elements
             // TODO what to do when element not found or access denied?
-            _load: function (type, name, callback, sub) {
+            _load: function (type, name, callback, sub, viewIndex) {
 
                 // get instance name from host
                 if (!type) {
@@ -250,7 +250,7 @@
                 // manual config
                 if (typeof name === 'object') {
                     // TODO how to set the elements name?
-                    return loader.call(self, factory, self._clone(classes[type]), name, callback, sub);
+                    return loader.call(self, factory, self._clone(classes[type]), name, callback, sub, viewIndex);
                 }
 
                 // views are only unique with instance name
@@ -297,7 +297,7 @@
                     }
 
                     // call factory
-                    loader.call(self, factory, clone, config, callback, sub);
+                    loader.call(self, factory, clone, config, callback, sub, viewIndex);
                 });
             },
 
@@ -642,7 +642,7 @@
 
     // load resources in parallel
     // TODO handle loading errors
-    function loader (factory, clone, config, callback, sub) {
+    function loader (factory, clone, config, callback, sub, viewIndex) {
         var self = this;
         var elements = 1;
         var count = 0;
@@ -687,7 +687,7 @@
         };
 
         // factory clone
-        factory && factory.call(self, clone, config, sub - 1);
+        factory && factory.call(self, clone, config, viewIndex - 1);
 
         // load resources
         if (config.L) {
@@ -698,16 +698,18 @@
                 // add sub elements to count
                 elements += config.L.elms.length;
 
+                viewIndex = viewIndex || 0;
+
                 // load sub elements
-                for (var i = 0, elm, vi = 1; i < config.L.elms.length; ++i) {
+                for (var i = 0, elm; i < config.L.elms.length; ++i) {
                     elm = config.L.elms[i];
 
-                    self._load(elm.type, elm.name, loaderHandler, vi);
-
-                    // increment render order index
+                    // increment view render order index
                     if (elm.type == 'V') {
-                        ++vi;
+                        ++viewIndex;
                     }
+
+                    self._load(elm.type, elm.name, loaderHandler, true, viewIndex);
                 }
             }
 

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -250,7 +250,7 @@
                 // manual config
                 if (typeof name === 'object') {
                     // TODO how to set the elements name?
-                    return loader.call(self, factory, self._clone(classes[type]), name, callback, sub, viewIndex);
+                    return loader.call(self, type, factory, self._clone(classes[type]), name, callback, sub, viewIndex);
                 }
 
                 // views are only unique with instance name
@@ -297,7 +297,7 @@
                     }
 
                     // call factory
-                    loader.call(self, factory, clone, config, callback, sub, viewIndex);
+                    loader.call(self, type, factory, clone, config, callback, sub, viewIndex);
                 });
             },
 
@@ -642,7 +642,7 @@
 
     // load resources in parallel
     // TODO handle loading errors
-    function loader (factory, clone, config, callback, sub, viewIndex) {
+    function loader (type, factory, clone, config, callback, sub, viewIndex) {
         var self = this;
         var elements = 1;
         var count = 0;
@@ -698,7 +698,7 @@
                 // add sub elements to count
                 elements += config.L.elms.length;
 
-                viewIndex = viewIndex || 0;
+                viewIndex = type === 'V' ? viewIndex || 0 : 0;
 
                 // load sub elements
                 for (var i = 0, elm; i < config.L.elms.length; ++i) {
@@ -788,7 +788,7 @@
             if (config.L) {
 
                 // load elements in parallel
-                loader.call(self, null, self, {L: config.L}, function () {});
+                loader.call(self, null, null, self, {L: config.L}, function () {});
 
                 // remove load config after elements are loaded
                 delete config.L;

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -250,7 +250,7 @@
                 // manual config
                 if (typeof name === 'object') {
                     // TODO how to set the elements name?
-                    return loader.call(self, type, factory, self._clone(classes[type]), name, callback, sub, viewIndex);
+                    return loader.call(self, factory, self._clone(classes[type]), name, callback, sub, viewIndex);
                 }
 
                 // views are only unique with instance name
@@ -297,7 +297,7 @@
                     }
 
                     // call factory
-                    loader.call(self, type, factory, clone, config, callback, sub, viewIndex);
+                    loader.call(self, factory, clone, config, callback, sub, viewIndex);
                 });
             },
 
@@ -642,7 +642,7 @@
 
     // load resources in parallel
     // TODO handle loading errors
-    function loader (type, factory, clone, config, callback, sub, viewIndex) {
+    function loader (factory, clone, config, callback, sub, viewIndex) {
         var self = this;
         var elements = 1;
         var count = 0;
@@ -695,10 +695,11 @@
             // load sub elements
             if (config.L.elms) {
 
+                // update the view index
+                self._vi = self._vi || 0;
+
                 // add sub elements to count
                 elements += config.L.elms.length;
-
-                viewIndex = type === 'V' ? viewIndex || 0 : 0;
 
                 // load sub elements
                 for (var i = 0, elm; i < config.L.elms.length; ++i) {
@@ -706,10 +707,10 @@
 
                     // increment view render order index
                     if (elm.type == 'V') {
-                        ++viewIndex;
+                        ++self._vi;
                     }
 
-                    self._load(elm.type, elm.name, loaderHandler, true, viewIndex);
+                    self._load(elm.type, elm.name, loaderHandler, true, self._vi);
                 }
             }
 
@@ -788,7 +789,7 @@
             if (config.L) {
 
                 // load elements in parallel
-                loader.call(self, null, null, self, {L: config.L}, function () {});
+                loader.call(self, null, self, {L: config.L}, function () {});
 
                 // remove load config after elements are loaded
                 delete config.L;

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -425,7 +425,7 @@
                 }
 
                 if (typeof self.dom === 'string') {
-                    self.dom = (self.scope || document).querySelector(self.dom);
+                    self.dom = (self.scope || doc).querySelector(self.dom);
                 }
 
                 // append html to dom
@@ -501,7 +501,7 @@
         },
 
         // view
-        V: function (view, config) {
+        V: function (view, config, index) {
             var self = this;
 
             // load css files
@@ -539,6 +539,9 @@
 
             // save view in instance
             self.view[config.name] = view;
+
+            // save render order on instance
+            (self._renderOrder = self._renderOrder || [])[index] = config.name;
         },
 
         // model
@@ -683,7 +686,7 @@
         };
 
         // factory clone
-        factory.call(self, clone, config);
+        factory.call(self, clone, config, sub - 1);
         clone._base = win_location.pathname;
 
         // load resources
@@ -696,8 +699,15 @@
                 elements += config.L.elms.length;
 
                 // load sub elements
-                for (var i = 0; i < config.L.elms.length; ++i) {
-                    self._load(config.L.elms[i].type, config.L.elms[i].name, loaderHandler, true);
+                for (var i = 0, elm, vi = 1; i < config.L.elms.length; ++i) {
+                    elm = config.L.elms[i];
+
+                    self._load(elm.type, elm.name, loaderHandler, vi);
+
+                    // increment render order index
+                    if (elm.type == 'V') {
+                        ++vi;
+                    }
                 }
             }
 
@@ -737,7 +747,7 @@
         // actions (dom)
         if (config.actions) {
             for (i = 0; i < config.actions.length; ++i) {
-                elm = document.querySelectorAll(config.actions[i].selector);
+                elm = doc.querySelectorAll(config.actions[i].selector);
                 if (elm) {
                     for (e = 0; e < elm.length; ++e) {
                         elm[e].addEventListener(
@@ -929,8 +939,8 @@
 
         // escape html chars
         if (!dont_escape_html) {
-            return str.replace(/[&\"<>]/g, function(char) {
-                return render_escape[char];
+            return str.replace(/[&\"<>]/g, function(_char) {
+                return render_escape[_char];
             });
         }
 
@@ -941,8 +951,8 @@
     // heavily inspired by the https://github.com/muut/riotjs render method
     function createTemplate (tmpl) {
         return new Function("_", "f", "e", "k", "_=_||{};return '" +
-            (tmpl || '').replace(/[\\\n\r']/g, function(char) {
-                return template_escape[char];
+            (tmpl || '').replace(/[\\\n\r']/g, function(_char) {
+                return template_escape[_char];
             }).replace(/{\s*([\w\.]+)\s*}/g, "' + f(_,'$1',e,k) + '") + "'"
         );
     }
@@ -957,10 +967,10 @@
                 if (!css[urls[i]]) {
                     css[urls[i]] = 1;
 
-                    var link = document.createElement('link');
+                    var link = doc.createElement('link');
                     link.setAttribute('rel', 'stylesheet');
                     link.setAttribute('href', urls[i]);
-                    document.head.appendChild(link);
+                    doc.head.appendChild(link);
                 }
             }
         }


### PR DESCRIPTION
The instance has now a property `_renderOrder`, which contains the view names in the same order as in the `L.elms` config of the composition. This is important especially for layout modules, which have multiple views that are rendered upon each other; nesting of views.

``` js
self._renderOrder = ["viewNameA", "viewNameN"];
```

With this info, a module can render views in the, of the users specified order.
