### PR TITLE
Wrap module scripts

### DIFF
--- a/lib/cache/file.js
+++ b/lib/cache/file.js
@@ -77,7 +77,7 @@ var Cache = {
     },
 
     // set an item
-    set: function (path, callback, dontWatch) {
+    set: function (path, callback, dontWatch, moduleFile) {
         var self = this;
 
         // check if file is already in cache
@@ -98,8 +98,12 @@ var Cache = {
 
             var mimeType = mime.lookup(path);
 
+            // wrap module code files
+            if (moduleFile) {
+                data = new Buffer("Z.wrap('" + moduleFile + "',function(require,module,exports){\n" + data.toString() + "\nreturn module});");
+
             // optimize html or css
-            if (!self._dontOptimize) {
+            } else if (!self._dontOptimize) {
                 switch (mimeType) {
                     case 'text/html':
                         data = minifyHtml(data.toString('utf8'), html_minifier_options);

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -371,7 +371,8 @@ function moduleFiles () {
     }
 
     // create file path
-    var path = env.Z_PATH_PROCESS_MODULES + self.link.path.join('/');
+    var moduleFile = self.link.path.join('/');
+    var path = env.Z_PATH_PROCESS_MODULES + moduleFile;
 
     // save compressed/compiled script in cache and send it to the client
     fileClient.set(path, function (err, script) {
@@ -384,7 +385,7 @@ function moduleFiles () {
         self.link.res.writeHead(200, script.http);
         self.link.res.end(script.data);
         return;
-    });
+    }, null, moduleFile);
 }
 
 // get mono client (http)


### PR DESCRIPTION
Append the wrapping code automatically while caching the script files. Now, the wrapping code must be removed from the existing client module files. Fixes #9 
