### PR TITLE
Add the short git commit id to js and css files 

### DIFF
--- a/lib/cache/file.js
+++ b/lib/cache/file.js
@@ -1,3 +1,4 @@
+var env = process.env;
 var fs = require('fs');
 var zlib = require('zlib');
 var mime = require('mime');
@@ -24,7 +25,7 @@ zlib.Z_DEFAULT_COMPRESSION = 9;
 
 module.exports = factory;
 
-function factory (name, noCompression, dontOptimize) {
+function factory (name, noCompression, dontOptimize, noFingerprints) {
 
     // return existing cache
     if (caches[name]) {
@@ -42,6 +43,9 @@ function factory (name, noCompression, dontOptimize) {
 
     // dont optimize html and css
     cache._dontOptimize = dontOptimize;
+
+    // disable filename fingerprints
+    cache._noFingerprints = noFingerprints;
 
     // save cache
     caches[name] = cache;
@@ -90,13 +94,28 @@ var Cache = {
             return callback(new Error('Invalid path.'));
         }
 
+        var mimeType = mime.lookup(path);
+        var fingerprint = '';
+        var cachePath = path;
+
+        // get filename fingerprint
+        if (mimeType === 'text/css' || mimeType === 'application/javascript') {
+
+            // split path
+            path = path.split('.');
+
+            // get fingerprint and remove fingerprint from read path
+            fingerprint = path.splice(path.length - 2, 1)[0];
+
+            // create path without fingerprint
+            path = path.join('.');
+        }
+
         fs.readFile(path, function (err, data) {
 
             if (err) {
                 return callback(err);
             }
-
-            var mimeType = mime.lookup(path);
 
             // wrap module code files
             if (moduleFile) {
@@ -111,12 +130,15 @@ var Cache = {
                     case 'text/css':
                         data = new minifyCSS({processImport: false}).minify(data.toString('utf8'));
                         break;
+                    case 'application/javascript':
+                        // TODO minify scripts
+                        break;
                 }
             }
 
             // don't compress data
             if (self._noCompression) {
-                return createCacheObject.call(self, path, data, mimeType, callback, dontWatch);
+                return createCacheObject.call(self, path, data, mimeType, fingerprint, cachePath, callback, dontWatch);
             }
 
             zlib.gzip(data, function (err, data) {
@@ -125,13 +147,13 @@ var Cache = {
                     return callback(err);
                 }
 
-                createCacheObject.call(self, path, data, mimeType, callback, dontWatch);
+                createCacheObject.call(self, path, data, mimeType, fingerprint, cachePath, callback, dontWatch);
             });
         });
     }
 };
 
-function createCacheObject (path, data, mimeType, callback, dontWatch) {
+function createCacheObject (path, data, mimeType, fingerprint, cachePath, callback, dontWatch) {
     var self = this;
 
     fs.stat(path, function (err, stats) {
@@ -140,7 +162,7 @@ function createCacheObject (path, data, mimeType, callback, dontWatch) {
             return callback(err);
         }
 
-        // watch file and update cache on change (only in dev mode? i think so..)
+        // watch file and update cache on change
         if (!dontWatch) {
             fs.watch(path, function (event) {
 
@@ -152,12 +174,13 @@ function createCacheObject (path, data, mimeType, callback, dontWatch) {
         }
 
         // save zipped data in cache
-        self._data[path] = data = {
+        self._data[cachePath] = data = {
             data: data,
 
             // create http headers
+            // TODO send not modified for non scrips and css
             http: {
-                'Cache-Control': 'public, max-age=31536000',
+                'Cache-Control': 'public, max-age=' + (fingerprint ? env.Z_HTTP_CACHE_MAX_AGE_FINGERPRINT : env.Z_HTTP_CACHE_MAX_AGE),
                 'Vary': 'Accept-Encoding',
                 'Last-Modified': stats.mtime,
                 'Content-Encoding': 'gzip',

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -1,5 +1,6 @@
 var env = process.env;
 var EventEmitter = require('events').EventEmitter;
+var fingerprint = require(env.Z_PATH_UTILS + 'fingerprint');
 
 var broadcast = require(env.Z_PATH_PROJECT + 'send').broadcast;
 var model = require(env.Z_PATH_MODELS + 'factory');
@@ -125,6 +126,10 @@ function linkSetup (instance, links, callback) {
     callback(null, instance._client);
 }
 
+function cacheAndInitInstance () {
+
+}
+
 // create instance
 function instanceFactory (name, module, compInst, callback) {
 
@@ -207,55 +212,69 @@ function instanceFactory (name, module, compInst, callback) {
     // attach the broadcast functionality
     instance._broadcast = broadcast;
 
-    // send original instance name to client, in case it's an alias
-    if (compInst.name !== name) {
-        instance._client.name = compInst.name;
+    // add fingerprints to scripts
+    var scripts = instance._client.L && instance._client.L.scripts ? instance._client.L.scripts : [];
+    fingerprint.addToFiles(instance._module, scripts, function (err, scripts) {
 
-        // save instance also under original name
-        pojoInstances.set(compInst.name, instance);
-    }
+        if (err) {
+            return callback(err);
+        }
 
-    // save instance in cache
-    // TODO update this cache when a instance config changes
-    pojoInstances.set(name, instance);
+        // update scripts
+        if (scripts) {
+            instance._client.L.scripts = scripts;
+        }
 
-    // require and init mono module
-    if (module.main) {
+        // send original instance name to client, in case it's an alias
+        if (compInst.name !== name) {
+            instance._client.name = compInst.name;
 
-        try {
-            var monoModule = require(env.Z_PATH_PROCESS_MODULES + instance._module + module.main);
+            // save instance also under original name
+            pojoInstances.set(compInst.name, instance);
+        }
 
-            if (typeof monoModule === 'function') {
-                monoModule.call(instance, instance._config || {}, function (err) {
+        // save instance in cache
+        // TODO update this cache when a instance config changes
+        pojoInstances.set(name, instance);
 
-                    if (err) {
-                        return callback(err);
-                    }
+        // require and init mono module
+        if (module.main) {
 
-                    // setup links
-                    if (compInst.links) {
-                        return linkSetup(instance, compInst.links, callback);
-                    }
+            try {
+                var monoModule = require(env.Z_PATH_PROCESS_MODULES + instance._module + module.main);
 
-                    callback(null, instance._client);
-                });
+                if (typeof monoModule === 'function') {
+                    monoModule.call(instance, instance._config || {}, function (err) {
+
+                        if (err) {
+                            return callback(err);
+                        }
+
+                        // setup links
+                        if (compInst.links) {
+                            return linkSetup(instance, compInst.links, callback);
+                        }
+
+                        callback(null, instance._client);
+                    });
+                }
+            } catch (err) {
+
+                // remove instance from cache
+                pojoInstances.rm(name);
+
+                callback('Module ' + compInst.name + ' init error: ' + err.toString());
             }
-        } catch (err) {
+        } else {
 
-            // remove instance from cache
-            pojoInstances.rm(name);
+            // setup links
+            if (compInst.links) {
+                return linkSetup(instance, compInst.links, callback);
+            }
 
-            callback('Module ' + compInst.name + ' init error: ' + err.toString());
+            callback(null, instance._client);
         }
-    } else {
-
-        // setup links
-        if (compInst.links) {
-            return linkSetup(instance, compInst.links, callback);
-        }
-
-        callback(null, instance._client);
-    }
+    });
 }
 
 // init module with newly created module instance as this

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -391,7 +391,7 @@ function moduleFiles () {
 // get mono client (http)
 function client (){
     var self = this;
-    var path = env.Z_PATH_CLIENT + self.link.path[0] + '.js';
+    var path = env.Z_PATH_CLIENT + self.link.path[0];
 
     // save compressed/compiled script in cache and send it to the client
     fileClient.set(path, function (err, script) {

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -391,7 +391,7 @@ function moduleFiles () {
 // get mono client (http)
 function client (){
     var self = this;
-    var path = env.Z_PATH_CLIENT + self.link.path[0];
+    var path = env.Z_PATH_CLIENT + self.link.path[0] + '.js';
 
     // save compressed/compiled script in cache and send it to the client
     fileClient.set(path, function (err, script) {

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -126,10 +126,6 @@ function linkSetup (instance, links, callback) {
     callback(null, instance._client);
 }
 
-function cacheAndInitInstance () {
-
-}
-
 // create instance
 function instanceFactory (name, module, compInst, callback) {
 
@@ -192,6 +188,9 @@ function instanceFactory (name, module, compInst, callback) {
         instance._client.L.scripts = compInst.L.scripts;
     }
 
+    // TODO better do callback buffering on instances, then copy the scripts
+    instance._scripts = instance._client.L && instance._client.L.scripts ? instance._client.L.scripts.slice() : [];
+
     // setup model events and add model factory to instance
     model.setup(instance);
     instance._model = model.factory;
@@ -213,8 +212,7 @@ function instanceFactory (name, module, compInst, callback) {
     instance._broadcast = broadcast;
 
     // add fingerprints to scripts
-    var scripts = instance._client.L && instance._client.L.scripts ? instance._client.L.scripts : [];
-    fingerprint.addToFiles(instance._module, scripts, function (err, scripts) {
+    fingerprint.addToFiles(instance._module, instance._scripts, function (err, scripts) {
 
         if (err) {
             return callback(err);

--- a/lib/project/config.js
+++ b/lib/project/config.js
@@ -33,6 +33,10 @@ process.env.Z_SEND_VIEW_REQ = 'V>';
 process.env.Z_SEND_MODULE_REQ = 'M';
 process.env.Z_SEND_CLIENT_REQ = 'Z';
 
+// http caching
+process.env.Z_HTTP_CACHE_MAX_AGE = 86400;
+process.env.Z_HTTP_CACHE_MAX_AGE_FINGERPRINT = 315600000000;
+
 // path values
 process.env.Z_PATH_CACHE = lib + 'cache/';
 process.env.Z_PATH_MODELS = lib + 'models/';
@@ -42,6 +46,7 @@ process.env.Z_PATH_PROJECT = lib + 'project/';
 process.env.Z_PATH_CLIENT = lib + 'client/';
 process.env.Z_PATH_MODULE = lib + 'module/';
 process.env.Z_PATH_VIEWS = lib + 'views/';
+process.env.Z_PATH_UTILS = lib + 'utils/';
 
 process.env.Z_PATH_PROCESS_REPO = repo;
 process.env.Z_PATH_PROCESS_PUBLIC = repo + 'public/';

--- a/lib/project/config.js
+++ b/lib/project/config.js
@@ -38,6 +38,7 @@ process.env.Z_HTTP_CACHE_MAX_AGE = 86400;
 process.env.Z_HTTP_CACHE_MAX_AGE_FINGERPRINT = 315600000000;
 
 // path values
+process.env.Z_PATH_ENGINE = engine_root;
 process.env.Z_PATH_CACHE = lib + 'cache/';
 process.env.Z_PATH_MODELS = lib + 'models/';
 process.env.Z_PATH_STORES = lib + 'stores/';

--- a/lib/project/router.js
+++ b/lib/project/router.js
@@ -30,7 +30,7 @@ function getLibs (callback) {
                     return callback(err);
                 }
 
-                fingerprint.addToFiles('public', data, callback);
+                fingerprint.addToFiles(env.Z_CORE_INST, data, callback);
             });
 
         // handle no libs
@@ -49,6 +49,11 @@ function sendClient (res) {
 
     // get libs paths
     getLibs(function (err, libs) {
+
+        if (err) {
+            res.writeHead(500, {'Content-Type': 'text/plain; charset=utf-8'});
+            res.end(err.toString());
+        }
 
         // get z path with fingerprint
         fingerprint.getZ(function (err, z_path) {

--- a/lib/project/router.js
+++ b/lib/project/router.js
@@ -1,6 +1,7 @@
 var env = process.env;
 var fs = require('fs');
 var gzip = require('zlib').gzip;
+var fingerprint = require(env.Z_PATH_UTILS + 'fingerprint');
 var cache = require(env.Z_PATH_CACHE + 'cache');
 var client;
 var resHeaders = {
@@ -29,12 +30,12 @@ function getLibs (callback) {
                     return callback(err);
                 }
 
-                callback(null, data);
+                fingerprint.addToFiles('public', data, callback);
             });
 
         // handle no libs
         } else {
-            callback();
+            callback(null, []);
         }
     });
 }
@@ -49,27 +50,31 @@ function sendClient (res) {
     // get libs paths
     getLibs(function (err, libs) {
 
-        var lib_src = '';
-        if (libs) {
-            for (var i = 0; i < libs.length; ++i) {
-                lib_src += "<script src='" + libs[i] + "'></script>\n";
-            }
-        }
+        // get z path with fingerprint
+        fingerprint.getZ(function (err, z_path) {
 
-        gzip(
-            "<!DOCTYPE html><html><head><link rel='icon' href='/favicon.ico'/>" +
-            "</head><body>" +
-                lib_src +
-                "<script src='/" + env.Z_OP_KEY + "/" + env.Z_CORE_INST + "/" + env.Z_SEND_CLIENT_REQ + "/Z.js'></script>" +
-            "</body></html>",
-            function (err, data) {
+            // add z file to the libs array
+            libs.push(z_path);
 
-                client = data;
-                resHeaders['Content-Length'] = client.length;
-                res.writeHead(200, resHeaders);
-                res.end(client);
+            var lib_src = '';
+            if (libs) {
+                for (var i = 0; i < libs.length; ++i) {
+                    lib_src += '<script src="' + libs[i] + '"></script>';
+                }
             }
-        );
+
+            gzip(
+                '<!DOCTYPE html><html><head><link rel="icon" href="/favicon.ico"/>' +
+                '</head><body>' + lib_src + '</body></html>',
+                function (err, data) {
+
+                    client = data;
+                    resHeaders['Content-Length'] = client.length;
+                    res.writeHead(200, resHeaders);
+                    res.end(client);
+                }
+            );
+        });
     });
 }
 

--- a/lib/proxy/config.js
+++ b/lib/proxy/config.js
@@ -2,7 +2,7 @@ var path = require('path');
 var lib = path.normalize(__dirname + '/../../') + 'lib/';
 
 // TODO this is only valid for current dev environment
-var repo = path.normalize(__dirname + '/../../../') + 'admin/'; // TODO dynamic value
+var repo = path.normalize(__dirname + '/../../../') + 'service/'; // TODO dynamic value
 
 // extend js functionality
 require(lib + 'utils/extend');

--- a/lib/utils/fingerprint.js
+++ b/lib/utils/fingerprint.js
@@ -4,6 +4,7 @@ var path_repos = env.HOME + '/engine_repos/';
 var suffix = /\.\w+$/;
 
 exports.addToFiles = addFileFingerprints;
+exports.getZ = getZFingerprint;
 
 // get latest commit ids of files
 function addFileFingerprints (root, files, callback) {
@@ -23,7 +24,7 @@ function addFileFingerprints (root, files, callback) {
     exec(command, {cwd: env.Z_PATH_PROCESS_REPO}, function (err , stdout, stderr) {
 
         if (err || !stdout) {
-            return callback(err);
+            return callback(err || new Error('No commit ids found.'));
         }
 
         // update files paths with the short git commit id
@@ -43,5 +44,19 @@ function addFileFingerprints (root, files, callback) {
         }
 
         callback(null, files);
+    });
+}
+
+// add a fingerprint to a file path
+function getZFingerprint (callback) {
+
+    exec('git log -n1 --pretty=format:"%h" lib/client/Z.js', {cwd: env.Z_PATH_ENGINE}, function (err , stdout, stderr) {
+
+        if (err || !stdout) {
+            return callback(err || new Error('No commit id for "Z.js" found.'));
+        }
+
+        // append fingerprint to Z.js
+        callback(null, '/' + env.Z_OP_KEY + '/' + env.Z_CORE_INST + '/' + env.Z_SEND_CLIENT_REQ + '/Z.' + stdout + '.js');
     });
 }

--- a/lib/utils/fingerprint.js
+++ b/lib/utils/fingerprint.js
@@ -48,9 +48,6 @@ function addFileFingerprints (module, files, callback) {
                 return callback(new Error('Invalid script path: ' + files[index]));
         }
 
-        console.log('cwd:', cwd);
-        console.log('file:', file);
-
         // get the commit id
         exec(
             'git log -n1 --pretty=format:"%h" ' + file,

--- a/lib/utils/fingerprint.js
+++ b/lib/utils/fingerprint.js
@@ -1,0 +1,47 @@
+var env = process.env;
+var exec = require('child_process').exec;
+var path_repos = env.HOME + '/engine_repos/';
+var suffix = /\.\w+$/;
+
+exports.addToFiles = addFileFingerprints;
+
+// get latest commit ids of files
+function addFileFingerprints (root, files, callback) {
+
+    if (!files) {
+        return callback(new Error('No file informations.'));
+    }
+
+    // create command
+    var command = '';
+    for (var i = 0; i < files.length; ++i) {
+        command += 'git log -n1 --pretty=format:"%h\n" ' + root + files[i] + ' && ';
+    }
+    command = command.slice(0, -4);
+
+    // execute command
+    exec(command, {cwd: env.Z_PATH_PROCESS_REPO}, function (err , stdout, stderr) {
+
+        if (err || !stdout) {
+            return callback(err);
+        }
+
+        // update files paths with the short git commit id
+        var fingerprints = stdout.split('\n').slice(0, -1);
+        for (var i = 0, file; i < files.length; ++i) {
+
+            // handle files without suffix
+            if (!suffix.test(files[i])) {
+                files[i] += '.' + fingerprints[i];
+                continue;
+            }
+
+            // handle files with suffix
+            file = files[i].split('.');
+            file.splice(file.length - 1, 0, fingerprints[i]);
+            files[i] = file.join('.');
+        }
+
+        callback(null, files);
+    });
+}

--- a/lib/utils/fingerprint.js
+++ b/lib/utils/fingerprint.js
@@ -2,49 +2,91 @@ var env = process.env;
 var exec = require('child_process').exec;
 var path_repos = env.HOME + '/engine_repos/';
 var suffix = /\.\w+$/;
+var external = /^(?:\/\/|http\:\/\/)/;
 
 exports.addToFiles = addFileFingerprints;
 exports.getZ = getZFingerprint;
 
 // get latest commit ids of files
-function addFileFingerprints (root, files, callback) {
+function addFileFingerprints (module, files, callback) {
 
     if (!files) {
         return callback(new Error('No file informations.'));
     }
 
-    // create command
-    var command = '';
-    for (var i = 0; i < files.length; ++i) {
-        command += 'git log -n1 --pretty=format:"%h\n" ' + root + files[i] + ' && ';
+    if (files.length === 0) {
+        return callback();
     }
-    command = command.slice(0, -4);
 
-    // execute command
-    exec(command, {cwd: env.Z_PATH_PROCESS_REPO}, function (err , stdout, stderr) {
+    // recursive handler
+    var handler = function (index) {
 
-        if (err || !stdout) {
-            return callback(err || new Error('No commit ids found.'));
+        // call back when all file path are updated
+        if (!files[index]) {
+            return callback(null, files);
         }
 
-        // update files paths with the short git commit id
-        var fingerprints = stdout.split('\n').slice(0, -1);
-        for (var i = 0, file; i < files.length; ++i) {
+        // check if file points to an external source
+        if (external.test(files[index])) {
+            return handler(++index);
+        }
 
-            // handle files without suffix
-            if (!suffix.test(files[i])) {
-                files[i] += '.' + fingerprints[i];
-                continue;
+        var file;
+        var cwd;
+
+        // get working directory and file path
+        switch (files[index][0]) {
+            case '.':
+                cwd = env.Z_PATH_PROCESS_MODULES + module;
+                file = cwd + files[index].substr(2);
+                break;
+            case '/':
+                cwd = env.Z_PATH_PROCESS_REPO;
+                file = env.Z_PATH_PROCESS_PUBLIC + files[index].substr(1);
+                break;
+            default:
+                return callback(new Error('Invalid script path: ' + files[index]));
+        }
+
+        console.log('cwd:', cwd);
+        console.log('file:', file);
+
+        // get the commit id
+        exec(
+            'git log -n1 --pretty=format:"%h" ' + file,
+            {cwd: cwd},
+            function (err , stdout, stderr) {
+
+                // handle error
+                if (err || !stdout) {
+                    return callback(err || new Error('No commit id found for "' + file + '" in repo "' + cwd + '"'));
+                }
+
+                // handle files without suffix
+                if (!suffix.test(file)) {
+
+                    // update files
+                    files[index] += '.' + stdout;
+
+                    // next loop
+                    return handler(++index);
+                }
+
+                // handle files with suffix
+                file = files[index].split('.');
+                file.splice(file.length - 1, 0, stdout);
+
+                // update files
+                files[index] = file.join('.');
+
+                // next loop
+                handler(++index);
             }
+        );
+    };
 
-            // handle files with suffix
-            file = files[i].split('.');
-            file.splice(file.length - 1, 0, fingerprints[i]);
-            files[i] = file.join('.');
-        }
-
-        callback(null, files);
-    });
+    // start recursive loop
+    handler(0);
 }
 
 // add a fingerprint to a file path

--- a/lib/views/factory.js
+++ b/lib/views/factory.js
@@ -44,6 +44,7 @@ function factory (name, role, callback) {
         // save roles in view
         view._roles = view.roles;
 
+        // add commit ids to css files
         fingerprint.addToFiles(null, view.css || [], function (err, css) {
 
             if (err) {

--- a/lib/views/factory.js
+++ b/lib/views/factory.js
@@ -1,6 +1,7 @@
 var env = process.env;
 var fs = require('fs');
 var cache = require(env.Z_PATH_CACHE + 'cache');
+var fingerprint = require(env.Z_PATH_UTILS + 'fingerprint');
 
 var pojoViews = cache.pojo('views');
 var compViews = cache.comp('views');
@@ -23,10 +24,12 @@ function factory (name, role, callback) {
     // check cache
     var view = pojoViews.get(name, role);
 
+    // handle no access
     if (view === 0) {
         return callback(new Error('View ' + name + ' not found.'));
     }
 
+    // return view from cache
     if (view) {
         return callback(null, view);
     }
@@ -41,28 +44,40 @@ function factory (name, role, callback) {
         // save roles in view
         view._roles = view.roles;
 
-        if (!view.html) {
-
-            // save view in cache
-            pojoViews.set(name, view);
-
-            return callback(null, view);
-        }
-
-        var path = env.Z_PATH_PROCESS_MARKUP + view.html.replace(/[^a-z0-9\/\.\-_]|\.\.\//gi, "");
-        snippetCache.set(path, function (err, snipped) {
+        fingerprint.addToFiles(null, view.css || [], function (err, css) {
 
             if (err) {
                 return callback(err);
             }
 
-            // add snipped to view
-            view.html = snipped.data.toString('utf8');
+            // update css
+            if (css) {
+                view.css = css;
+            }
 
-            // save view in cache
-            pojoViews.set(name, view);
+            if (!view.html) {
 
-            callback(null, view);
+                // save view in cache
+                pojoViews.set(name, view);
+
+                return callback(null, view);
+            }
+
+            var path = env.Z_PATH_PROCESS_MARKUP + view.html.replace(/[^a-z0-9\/\.\-_]|\.\.\//gi, "");
+            snippetCache.set(path, function (err, snipped) {
+
+                if (err) {
+                    return callback(err);
+                }
+
+                // add snipped to view
+                view.html = snipped.data.toString('utf8');
+
+                // save view in cache
+                pojoViews.set(name, view);
+
+                callback(null, view);
+            });
         });
     });
 }


### PR DESCRIPTION
Following cache optimizations are implemented:
- The latest git commit id is appended to the end of the filename, to force the browser to reload the file.
- The `max-age` value for client files other then `js` and `css`is now `86400ms` (one day). This optimized the caching issue for files that are referenced directly in the code, ex. css background images etc.

Example: `/css/style.css` becomes `/css/style.c93caae.css`

I don't use a query string `/css/style.css?c93caae`, because this is incompatible with proxy caching. [Here](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#invalidating-and-updating-cached-responses) you'll find more infos about this topic.

Fixes #13
