### PR TITLE
Extenting the instance class with the "_deep" method

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -301,6 +301,13 @@
                 });
             },
 
+            // clone object
+            _clone: function (object) {
+                var O = function() {};
+                O.prototype = object || {};
+                return new O();
+            },
+
             // this._path('Object.key.key.value'[, {'key': {'key': {'value': 123}}}]);
             _path: function (path, scope, stop) {
 
@@ -322,26 +329,17 @@
                 return scope;
             },
 
-            // clone object
-            _clone: function (object) {
-                var O = function() {};
-                O.prototype = object || {};
-                return new O();
-            },
-
-            // convert object to arrays
-            _toArray: function (object) {
-                return Array.prototype.slice.call(object);
-            },
-
             // flat objects
             _flat: function (object) {
                 var output = {};
+                var value;
+                var newKey;
 
+                // recusrive handler
                 function step(obj, prev) {
                     for (var key in obj) {
-                        var value = obj[key];
-                        var newKey = prev + key;
+                        value = obj[key];
+                        newKey = prev + key;
 
                         if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
 
@@ -355,9 +353,45 @@
                     }
                 }
 
+                // start recursive loop
                 step(object, '');
 
                 return output;
+            },
+
+            // create a deep object
+            _deep: function (object) {
+
+                var result = {};
+                var parentObj = result;
+                var key;
+                var subkeys;
+                var subkey;
+                var last;
+                var keys = Object.keys(object);
+
+                for (var i = 0; i < keys.length; ++i) {
+
+                    key = keys[i];
+                    subkeys = key.split('.');
+                    last = subkeys.pop();
+
+                    for (var ii = 0; ii < subkeys.length; ++ii) {
+                        subkey = subkeys[ii];
+                        parentObj[subkey] = typeof parentObj[subkey] === 'undefined' ? {} : parentObj[subkey];
+                        parentObj = parentObj[subkey];
+                    }
+
+                    parentObj[last] = object[key];
+                    parentObj = result;
+                }
+
+                return result;
+            },
+
+            // convert object to arrays
+            _toArray: function (object) {
+                return Array.prototype.slice.call(object);
             },
 
             // random string generator
@@ -862,8 +896,13 @@
                         // add data to the data object
                         for (key in emit.add) {
                             _path = emit.add[key].replace(find_index, '.' + (elmIndex || 0));
+
+                            // update data object
                             data[key] = self._path(_path) || self._path(_path, data, true);
                         }
+
+                        // create deep object out of flat keys
+                        data = self._deep(data);
                     }
 
                     // update scope


### PR DESCRIPTION
The `_deep` method creates deep objects from flat paths with dot notation.

Example: `{item.path.key: "..."}` becomes `{item: {path: {key: "..."}}}`.

Also create deep objects after the `add` added values to the event data object.

Fixes #64 
