### PR TITLE
Minify javscript files in production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ open http://github.jillix.admin.jillix.ch:10001/
 ## Start proxy
 
 ```sh
-$ node lib/proxy/server.js
+# dev mode
+$ node lib/proxy/server.js [PORT]
+
+# production mode
+$ node lib/proxy/server.js [PORT] PRO
 ```

--- a/lib/cache/file.js
+++ b/lib/cache/file.js
@@ -4,6 +4,7 @@ var zlib = require('zlib');
 var mime = require('mime');
 var minifyHtml = require('html-minifier').minify;
 var minifyCSS =  require('clean-css');
+var UglifyJS = require("uglify-js");
 var clone = require(env.Z_PATH_UTILS + 'clone');
 var Fingerprint = require(env.Z_PATH_UTILS + 'fingerprint');
 
@@ -139,18 +140,21 @@ var Cache = {
             // wrap module code files
             if (module) {
                 data = new Buffer("Z.wrap('" + filePath + "',function(require,module,exports){\n" + data.toString() + "\nreturn module});");
+            }
 
-            // optimize html or css
-            } else if (!self._dontOptimize) {
+            // minify js, html or css
+            if (!self._dontOptimize) {
                 switch (mimeType) {
                     case 'text/html':
-                        data = minifyHtml(data.toString('utf8'), html_minifier_options);
+                        data = minifyHtml(data.toString(), html_minifier_options);
                         break;
                     case 'text/css':
-                        data = new minifyCSS({processImport: false}).minify(data.toString('utf8'));
+                        data = new minifyCSS({processImport: false}).minify(data.toString());
                         break;
                     case 'application/javascript':
-                        // TODO minify scripts
+                        if (env.Z_PRODUCTION && (data = UglifyJS.minify(data.toString(), {fromString: true}))) {
+                            data = data.code;
+                        }
                         break;
                 }
             }

--- a/lib/project/config.js
+++ b/lib/project/config.js
@@ -1,14 +1,32 @@
 var path = require('path');
 var engine_root = path.normalize(__dirname + '/../../');
 var lib = engine_root + 'lib/';
-var repo = process.argv[2][0] === '/' ? process.argv[2] : path.normalize(engine_root + '/../' + process.argv[2]) + '/';    // TODO dynamic value
 
+// ------------------------------------------------------------------ CLI CHECKS
+// read repo path
+var repo = process.argv[2];
+if (!repo) {
+    throw new Error('No repo path argument.');
+}
+
+// get the path to the repo
+repo = repo[0] === '/' ? repo : path.normalize(engine_root + '/../' + repo) + '/';
+
+// get port
+if (!process.argv[3] || !process.argv[3].replace(/[^0-9]/g, '')) {
+    throw new Error('Not port argument.');
+}
+process.env.Z_PORT = process.argv[3];
+
+// check production mode
+if (process.argv[4] === 'PRO') {
+    process.env.Z_PRODUCTION = 'true';
+}
+
+// ------------------------------------------------------------------ ENV CEHCKS
 // access values
-process.env.Z_USER = '530639e09060f4703737e017';                            // TODO dynamic value
-process.env.Z_KEY = '0ULtAr8iH151p69q2XYTCht';                              // TODO dynamic value
-
-// process values
-process.env.Z_PORT = process.argv[3] || 10001;                              // TODO dynamic value
+process.env.Z_USER = '530639e09060f4703737e017';    // TODO get value from env
+process.env.Z_KEY = '0ULtAr8iH151p69q2XYTCht';      // TODO get value from env
 
 // session values
 process.env.Z_SESSION_PUBLIC = '*';

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ws": "0.4.32",
     "mime": "1.2.11",
     "cookie": "0.1.2",
+    "uglify-js": "2.4.15",
     "html-minifier": "0.6.8",
     "clean-css": "2.2.16",
     "oriento": "0.5.1"


### PR DESCRIPTION
To start the `engine` in `production` mode, there is now a new `cli` argument:

``` sh
# start engine in production mode
node engine /path/to/repo 10001 PRO
```

The `dev` mode is like before:

``` sh
# start engine in dev mode
node engine /path/to/repo 10001
```

When `engine` runs in `production` mode the `javascript` files are now minified with [UglifyJS2](https://github.com/mishoo/UglifyJS2).

Fixes #68
