### PR TITLE
Error handling

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -1218,7 +1218,7 @@
 
             // show errors in console
             if (err) {
-                console.error(instance + ':', err);
+                console.error(instance + ':', err, data);
             }
 
             if (instance && cache.I[instance] && wsCache[cbId]) {

--- a/lib/project/send.js
+++ b/lib/project/send.js
@@ -13,6 +13,16 @@ exports.setWebsocket = function (ws) {
     WS = ws;
 };
 
+function stringify(input) {
+    if (typeof input === "string") {
+        return input;
+    }
+    if (input instanceof Error) {
+        input = input.message;
+    }
+    return input;
+}
+
 function convertToBuffer (data, headers) {
 
     if (data === undefined) {
@@ -25,6 +35,10 @@ function convertToBuffer (data, headers) {
 
     if (data instanceof Buffer) {
         return data;
+    }
+
+    if (data instanceof Error) {
+        data = new Buffer(data.message);
     }
 
     try {
@@ -114,7 +128,7 @@ function httpError (req, res, code, err) {
 
 // send server websocket errors
 function wsError (ws, err, msgId) {
-    ws.send(createMessage(env.Z_CORE_INST, 'error', err, null, msgId));
+    ws.send(createMessage(env.Z_CORE_INST, 'error', stringify(err), null, msgId));
 }
 
 // request response for operations

--- a/lib/project/server.js
+++ b/lib/project/server.js
@@ -145,7 +145,7 @@ var httpServer = http.createServer(function (req, res) {
     var self = this;
     var args = arguments;
 
-    var d = Domain.create();
+    var d = domain.create();
     d.on("error", function(err) {
         send.httpError(req, res, 404, new Error('Internal server error.'));
         // TODO Mad science

--- a/lib/project/server.js
+++ b/lib/project/server.js
@@ -41,7 +41,7 @@ function requestHandler (err, req, res) {
     }
 
     var url = parse(req.url, true);
-    var path = url.pathname.replace(/\/$|^\//g, "").split("/", 42);
+    var path = url.pathname.replace(/\/$|^\//g, '').split('/', 42);
 
     if (path[0] === env.Z_OP_KEY) {
 
@@ -120,7 +120,7 @@ function connectionHandler (err, ws) {
         var cbId = data[0][2];
         var d = domain.create();
 
-        d.on("error", function(err) {
+        d.on('error', function(err) {
             send.wsError(ws, new Error('Internal server error.'), cbId);
             exitProcessNicely(err);
         });
@@ -128,7 +128,7 @@ function connectionHandler (err, ws) {
         d.run(function() {
             // check if instance and event exists
             if (instance) {
-                // mono ws protocoll: ["instanceName:event:msgid","err","data"]
+                // Engine ws protocoll: ['instanceName:event:msgid','err','data']
                 var message = clone(instance);
                 message.link = {
                     _: instance,
@@ -160,7 +160,7 @@ var httpServer = http.createServer(function (req, res) {
     var args = arguments;
 
     var d = domain.create();
-    d.on("error", function(err) {
+    d.on('error', function(err) {
         send.httpError(req, res, 500, new Error('Internal server error.'));
         exitProcessNicely(err);
     });

--- a/lib/project/server.js
+++ b/lib/project/server.js
@@ -8,6 +8,7 @@ var route = require('./router');
 var send = require('./send');
 var middleware = require(env.Z_PATH_MIDDLEWARE + 'session');
 var cache = require(env.Z_PATH_CACHE + 'cache');
+var domain = require('domain');
 
 // create instance cache with role check
 var instanceCache = cache.pojo('instances', true);
@@ -138,7 +139,26 @@ function connectionHandler (err, ws) {
 require(env.Z_PATH_MODULE + 'module')();
 
 // start http server
-var httpServer = http.createServer(middleware(requestHandler));
+var rHandler = middleware(requestHandler);
+var httpServer = http.createServer(function (req, res) {
+
+    var self = this;
+    var args = arguments;
+
+    var d = Domain.create();
+    d.on("error", function(err) {
+        send.httpError(req, res, 404, new Error('Internal server error.'));
+        // TODO Mad science
+        process.exit(1);
+    });
+
+    d.add(res);
+    d.add(req);
+
+    d.run(function() {
+        rHandler.apply(self, args);
+    });
+});
 
 // start ws server
 var ws = new WebSocketServer({server: httpServer});

--- a/lib/project/server.js
+++ b/lib/project/server.js
@@ -10,6 +10,12 @@ var middleware = require(env.Z_PATH_MIDDLEWARE + 'session');
 var cache = require(env.Z_PATH_CACHE + 'cache');
 var domain = require('domain');
 
+function exitProcessNicely(err) {
+    console.log(err && err.stack);
+    // TODO Mad science
+    process.exit(1);
+}
+
 // create instance cache with role check
 var instanceCache = cache.pojo('instances', true);
 
@@ -112,26 +118,34 @@ function connectionHandler (err, ws) {
 
         // id for message callbacks
         var cbId = data[0][2];
+        var d = domain.create();
 
-        // check if instance and event exists
-        if (instance) {
-            // mono ws protocoll: ["instanceName:event:msgid","err","data"]
-            var message = clone(instance);
-            message.link = {
-                _: instance,
-                ws: ws,
-                event: data[0][1],
-                send: send.message,
-                id: cbId,
-                role: role
-            };
+        d.on("error", function(err) {
+            send.wsError(ws, new Error('Internal server error.'), cbId);
+            exitProcessNicely(err);
+        });
 
-            // emit event
-            message.emit(message.link.event, data[1], data[2]);
+        d.run(function() {
+            // check if instance and event exists
+            if (instance) {
+                // mono ws protocoll: ["instanceName:event:msgid","err","data"]
+                var message = clone(instance);
+                message.link = {
+                    _: instance,
+                    ws: ws,
+                    event: data[0][1],
+                    send: send.message,
+                    id: cbId,
+                    role: role
+                };
 
-        } else {
-            send.wsError(ws, new Error('Instance or event not found'), cbId);
-        }
+                // emit event
+                message.emit(message.link.event, data[1], data[2]);
+
+            } else {
+                send.wsError(ws, new Error('Instance or event not found'), cbId);
+            }
+        });
     });
 }
 
@@ -147,9 +161,8 @@ var httpServer = http.createServer(function (req, res) {
 
     var d = domain.create();
     d.on("error", function(err) {
-        send.httpError(req, res, 404, new Error('Internal server error.'));
-        // TODO Mad science
-        process.exit(1);
+        send.httpError(req, res, 500, new Error('Internal server error.'));
+        exitProcessNicely(err);
     });
 
     d.add(res);


### PR DESCRIPTION
- Use `domain` library to handle errors (Fixes #39)
- Convert errors to string (Fixes #94)
