### PR TITLE
Response with 404 when a file is not found by router 

### DIFF
--- a/lib/project/router.js
+++ b/lib/project/router.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var gzip = require('zlib').gzip;
 var fingerprint = require(env.Z_PATH_UTILS + 'fingerprint');
 var cache = require(env.Z_PATH_CACHE + 'cache');
+var testSuffix = /\.[a-zA-Z0-9]+$/;
 var client;
 var resHeaders = {
     'Cache-Control': 'public, max-age=31536000',
@@ -98,9 +99,20 @@ function route (pathname, req, res) {
         return sendClient(res, req._sidInvalid);
     }
 
-    publicCache.set(env.Z_PATH_PROCESS_PUBLIC + pathname, function (err, file) {
+    publicCache.set(env.Z_PATH_PROCESS_PUBLIC + pathname.substr(1), function (err, file) {
 
         if (err) {
+
+            // return not found if path has a suffix
+            if (testSuffix.test(pathname)) {
+
+                res.writeHead(404, {'Content-Type': 'text/plain; charset=utf-8'});
+                res.end('File "' + pathname + '" not found.');
+
+                return;
+            }
+
+            // send client
             return sendClient(res, req._sidInvalid);
         }
 


### PR DESCRIPTION
The router should return a `404` when a file is requested and not found, instead of sending the `Z.js` file in the response.
