### PR TITLE
Define a public and a private root instance 

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -230,7 +230,7 @@
                 // get instance name from host
                 if (!type) {
                     type = 'I';
-                    name = win_location.hostname.replace(/\./g, '_');
+                    name = '_';
                 }
 
                 var self = this;

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -300,6 +300,16 @@ function loadinstance (name, role, callback) {
 function load (err, instance, callback) {
     var self = this;
 
+    // create start instance with hostname
+    if (instance === '_') {
+        instance = self.link.ws.upgradeReq.headers.host.split(':')[0].replace(/\./g, '_');
+
+        // get the public version of the start instance
+        if (!self.link.role) {
+            instance += '.pub';
+        }
+    }
+
     // send client config from cache
     var cachedInstance = pojoInstances.get(instance, self.link.role);
 


### PR DESCRIPTION
It should be possible to load under the same URL a different root `instance`, when a `session` with a `role` exists.

To make a starter `instance` public, just append `.pub` the instance symlink in the compsition:
`my_domain_com.json` -> `my_domain_com.pub.json`
