### PR TITLE
Instance link factory

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -493,7 +493,7 @@
                 var self = this;
 
                 // emit server event
-                self._.emit('m>', null, {
+                self._.emit('Q>', null, {
                     m: self._name,
                     q: query,
                     d: data

--- a/lib/models/factory.js
+++ b/lib/models/factory.js
@@ -18,15 +18,9 @@ for (var i = 0; i < adapters.length; ++i) {
     adapters[adapters[i]] = adapatersPath + adapters[i] + '/' + adapters[i] + '.js';
 }
 
-exports.setup = setup;
+exports.service = factoryService;
 exports.factory = factory;
-
-function setup (instance) {
-
-    // listen for message events
-    instance._request = messageHandler;
-    instance._modelService = factoryService;
-}
+exports.queries = messageHandler;
 
 function factory (name, role, callback) {
 

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -182,12 +182,16 @@ function instanceFactory (name, module, compInst, callback) {
     // TODO better do callback buffering on instances, then copy the scripts
     instance._scripts = instance._client.L && instance._client.L.scripts ? instance._client.L.scripts.slice() : [];
 
-    // setup model events and add model factory to instance
-    model.setup(instance);
-    instance._model = model.factory;
+    // attach create link hander method to instance
+    instance._link = linkHandler;
 
-    // setup view events and add model factory to instance
-    instance._view = view(instance);
+    // add model factory to instance and setup model events
+    instance.model = model.factory;
+    instance._link({event: env.Z_SEND_MODEL_REQ, call: model.service});
+    instance._link({event: env.Z_SEND_QUERY_REQ, call: model.queries});
+
+    // setup view service
+    instance._link({event: env.Z_SEND_VIEW_REQ, call: view});
 
     // handle send configurations
     if (!compInst.links) {
@@ -196,8 +200,6 @@ function instanceFactory (name, module, compInst, callback) {
 
     // set up core send events
     compInst.links.push({event: env.Z_SEND_INST_REQ, call: load});
-    compInst.links.push({event: env.Z_SEND_MODEL_REQ, call: instance._modelService});
-    compInst.links.push({event: env.Z_SEND_VIEW_REQ, call: instance._viewService});
 
     // attach the broadcast functionality
     instance._broadcast = broadcast;
@@ -357,10 +359,6 @@ function init () {
     });
     instance.on(env.Z_SEND_MODULE_REQ, moduleFiles);
     instance.on(env.Z_SEND_CLIENT_REQ, client);
-
-    // setup model events and add model factory to instance
-    model.setup(instance);
-    instance._model = model.factory;
 
     // attach the broadcast functionality
     instance._broadcast = broadcast;

--- a/lib/project/config.js
+++ b/lib/project/config.js
@@ -39,6 +39,9 @@ process.env.Z_OP_KEY = '@';
 process.env.Z_CORE_INST = 'Z';
 process.env.Z_CLIENT_LIBS = repo + 'libs.json';
 
+// module role
+process.env.Z_ROLE_MODULE = 'module';
+
 // send events
 process.env.Z_SEND_INST_REQ = 'I>';
 process.env.Z_SEND_MODEL_REQ = 'M>';

--- a/lib/project/config.js
+++ b/lib/project/config.js
@@ -28,6 +28,9 @@ if (process.argv[4] === 'PRO') {
 process.env.Z_USER = '530639e09060f4703737e017';    // TODO get value from env
 process.env.Z_KEY = '0ULtAr8iH151p69q2XYTCht';      // TODO get value from env
 
+// system roles
+process.env.Z_ROLE_MODULE = '_module';
+
 // session values
 process.env.Z_SESSION_PUBLIC = '*';
 process.env.Z_SESSION_ROLE_KEY = 'role';
@@ -42,6 +45,7 @@ process.env.Z_CLIENT_LIBS = repo + 'libs.json';
 // send events
 process.env.Z_SEND_INST_REQ = 'I>';
 process.env.Z_SEND_MODEL_REQ = 'M>';
+process.env.Z_SEND_QUERY_REQ = 'Q>';
 process.env.Z_SEND_VIEW_REQ = 'V>';
 process.env.Z_SEND_MODULE_REQ = 'M';
 process.env.Z_SEND_CLIENT_REQ = 'Z';

--- a/lib/views/factory.js
+++ b/lib/views/factory.js
@@ -7,16 +7,7 @@ var pojoViews = cache.pojo('views', true);
 var compViews = cache.comp('views');
 var snippetCache = cache.file('snippets', true);
 
-module.exports = setup;
-
-function setup (instance) {
-
-    // setup view
-    instance._viewService = factoryService;
-
-    // return view factory
-    return factory;
-}
+module.exports = factoryService;
 
 function factory (name, role, callback) {
     var self = this;


### PR DESCRIPTION
Instances have now the option to create their own `links` manually.
Example (this is the instance):

``` js
// server
this._link({event: "saveForm", call: saveData});
```

``` js
// client
this.emit('saveForm', null, {form: "data"})
```

**important note**
The module factory `this._module` is now `this.module`.
