### PR TITLE
Global views

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -248,11 +248,6 @@
                     return loader.call(self, factory, self._clone(classes[type]), name, callback, sub, viewIndex);
                 }
 
-                // views are only unique with instance name
-                if (type === 'V') {
-                    cacheKey += self._name;
-                }
-
                 // get item from cache
                 if (cache[type][cacheKey]) {
 

--- a/lib/views/factory.js
+++ b/lib/views/factory.js
@@ -87,8 +87,6 @@ function factoryService (err, name, callback) {
         return callback('Bad message');
     }
 
-    name = self._name + '_' + name;
-
     // create model
     factory.call(self, name, self.link.role, function (err, view) {
 


### PR DESCRIPTION
Don't namespace views with the `instance` name. That makes it possible to reuse `views` and load them from every `element`. Fixes #108 
