### PR TITLE
Default wrap client script files

### DIFF
--- a/lib/cache/file.js
+++ b/lib/cache/file.js
@@ -34,7 +34,7 @@ zlib.Z_DEFAULT_COMPRESSION = 9;
 
 module.exports = factory;
 
-function factory (name, noCompression, dontOptimize) {
+function factory (name, options) {
 
     // return existing cache
     if (caches[name]) {
@@ -50,11 +50,17 @@ function factory (name, noCompression, dontOptimize) {
     // create data container
     cache._data = {};
 
+    // working dir
+    cache._wd = options.wd || env.Z_PATH_PROCESS_PUBLIC;
+
+    // dont wrap js code
+    cache._noWrap = options.noWrap;
+
     // configure compression
-    cache._noCompression = noCompression;
+    cache._noCompression = options.noCompression;
 
     // dont optimize html and css
-    cache._dontOptimize = dontOptimize;
+    cache._dontOptimize = options.dontOptimize;
 
     // save cache
     caches[name] = cache;
@@ -96,67 +102,51 @@ var Cache = {
     },
 
     // set an item
-    set: function (path, callback, module) {
+    set: function (path, callback, allowedFiles, prependPath) {
         var self = this;
 
-        // check if file is already in cache
-        if (self._data[path]) {
-            return callback(null, self._data[path], true);
+        // clean path and get figerprint info
+        var pathInfo = Fingerprint.cleanPath(path);
+
+        // create a clean path without the fingerprint
+        var cleanPath = (prependPath || '') + pathInfo.path;
+
+        // check if the file is allowed
+        if (allowedFiles) {
+
+            var found = false;
+
+            // try to find the file
+            for (var i = 0; i < allowedFiles.length; ++i) {
+                if (allowedFiles[i][0] !== '/' && allowedFiles[i].substr(2) === pathInfo.path) {
+                    found = true;
+                    break;
+                }
+            }
+
+            // return not found if requested file is not found in "allowedFiles"
+            if (!found) {
+                return callback(new Error('File not found.'));
+            }
         }
 
         // path must be absolute
-        if (path.indexOf('../') !== -1) {
+        if (cleanPath.indexOf('../') !== -1) {
             return callback(new Error('Invalid path.'));
         }
 
-        var mimeType = mime.lookup(path);
-        var fingerprint = '';
-        var cachePath = path;
-
-        // modules dependencies can only request javascript files
-        if (module && mimeType !== 'application/javascript') {
-            return callback(new Error('File not found.'));
+        // check if file is already in cache
+        if (self._data[cleanPath]) {
+            return callback(null, self._data[cleanPath], true);
         }
 
-        // get filename fingerprint
-        if (mimeType === 'text/css' || mimeType === 'application/javascript') {
+        var mimeType = mime.lookup(cleanPath);
+        var readPath = self._wd + (cleanPath[0] === '/' ? cleanPath.substr(1) : cleanPath);
 
-            // get clean path an fingerprint
-            path = Fingerprint.cleanPath(path);
-            fingerprint = path.fingerprint;
-            path = path.path;
-
-            // check if requested file is in dependecies
-            if (module) {
-
-                var modulePath = module.path.slice(0, 4).join('/');
-                var filePath = module.path.join('/').replace(reRemoveFingerprint, '.js');
-                var found = false;
-
-                // check if file is in dependency
-                for (var i = 0; i < module.deps.length; ++i) {
-                    if (modulePath + '/' + module.deps[i].substr(2) === filePath) {
-                        found = true;
-                        break;
-                    }
-                }
-
-                // return not found if requested file is not found in dependecies
-                if (!found) {
-                    return callback(new Error('File not found.'));
-                }
-            }
-        }
-
-        fs.readFile(path, function (err, data) {
+        fs.readFile(readPath, function (err, data) {
 
             if (err) {
                 return callback(err);
-            }
-
-            // wrap module code files
-            if (module) {
-                data = new Buffer("Z.wrap('" + filePath + "',function(require,module,exports){\n" + data.toString() + "\nreturn module});");
             }
 
             // minify js, html or css
@@ -169,6 +159,12 @@ var Cache = {
                         data = new minifyCSS({processImport: false}).minify(data.toString());
                         break;
                     case 'application/javascript':
+
+                        // wrap javascript files
+                        if (!self._noWrap) {
+                            data = "Z.wrap('" + cleanPath + "',function(require,module,exports){\n" + data.toString() + "\nreturn module});";
+                        }
+
                         if (env.Z_PRODUCTION && (data = UglifyJS.minify(data.toString(), {fromString: true}))) {
                             data = data.code;
                         }
@@ -178,7 +174,7 @@ var Cache = {
 
             // don't compress data
             if (self._noCompression) {
-                return createCacheObject.call(self, path, data, mimeType, fingerprint, cachePath, callback);
+                return createCacheObject.call(self, cleanPath, readPath, data, mimeType, pathInfo.fingerprint, callback);
             }
 
             zlib.gzip(data, function (err, data) {
@@ -187,31 +183,31 @@ var Cache = {
                     return callback(err);
                 }
 
-                createCacheObject.call(self, path, data, mimeType, fingerprint, cachePath, callback);
+                createCacheObject.call(self, cleanPath, readPath, data, mimeType, pathInfo.fingerprint, callback);
             });
         });
     }
 };
 
-function createCacheObject (path, data, mimeType, fingerprint, cachePath, callback) {
+function createCacheObject (cleanPath, readPath, data, mimeType, fingerprint, callback) {
     var self = this;
 
-    fs.stat(path, function (err, stats) {
+    fs.stat(readPath, function (err, stats) {
 
         if (err) {
             return callback(err);
         }
 
         // watch for file changes
-        if (self._data[cachePath] !== null) {
-            fs.watch(path, function (event, filename) {
+        if (self._data[cleanPath] !== null) {
+            fs.watch(readPath, function (event, filename) {
 
                 // remove cached data on file change, to force reload
-                if (event === 'change' && self._data[cachePath]) {
-                    self._data[cachePath] = null;
+                if (event === 'change' && self._data[cleanPath]) {
+                    self._data[cleanPath] = null;
 
                     // emit item change event
-                    self.obs.emit('change:' + cachePath);
+                    self.obs.emit('change:' + cleanPath);
                 }
             });
         }
@@ -238,10 +234,10 @@ function createCacheObject (path, data, mimeType, fingerprint, cachePath, callba
         }
 
         // know if item was removed due a composition change or manual
-        var changed = self._data[cachePath] === null ? true : false;
+        var changed = self._data[cleanPath] === null ? true : false;
 
         // save zipped data in cache
-        self._data[cachePath] = data;
+        self._data[cleanPath] = data;
 
         // return data
         callback(null, data, changed);

--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -749,7 +749,7 @@
 
             // load scripts
             if (config.L.scripts) {
-                loadJS(config.module, config.L.scripts, loaderHandler);
+                loadJS(config.module, config.main || 0, config.L.scripts, loaderHandler);
             } else {
                 loaderHandler();
             }
@@ -1029,7 +1029,7 @@
 
     // ----------------------------------------------------------- SCRIPT LOADER
 
-    // commonjs require
+    // CommonJS require
     function require (module) {
         return function (name) {
             if (name.indexOf('../') === 0) {
@@ -1043,18 +1043,6 @@
             } else if (name.indexOf('./') === 0) {
                 var path = module.path.join('/');
                 name = module.base + (path ? path + '/' : '') + name.substr(2);
-            } else {
-
-                if (name.split('/').length < 5 && name[name.length - 1] !== '/') {
-                    name += '/';
-                }
-
-                for (var script in modules) {
-                    if (script.indexOf(name) === 0) {
-                        name = script;
-                        break;
-                    }
-                }
             }
 
             name += name.slice(-3) !== '.js' ? '.js' : '';
@@ -1065,7 +1053,7 @@
     }
 
     // create CommonJS modules in order of the dependencies-
-    function createCommonJsModulesInOrder (moduleSources, callback) {
+    function createCommonJsModulesInOrder (main, moduleSources, callback) {
 
         // init modules in order (desc)
         for (var i = (moduleSources.length - 1), l = 0; i >= l; --i) {
@@ -1109,7 +1097,7 @@
         }
 
         // return first module of dependency list
-        callback(null, modules[moduleSources[0]] ? modules[moduleSources[0]].exports : null);
+        callback(null, modules[moduleSources[main]] ? modules[moduleSources[main]].exports : null);
     }
 
     // load handler for external dependencies
@@ -1121,12 +1109,12 @@
     }
 
     // load scripts (script tag)
-    function loadJS (moduleName, moduleSources, callback) {
+    function loadJS (moduleName, mainSource, moduleSources, callback) {
 
         var length = moduleSources.length;
         var modDepLoaded = function () {
             if (--length === 0) {
-                createCommonJsModulesInOrder(moduleSources, callback);
+                createCommonJsModulesInOrder(mainSource, moduleSources, callback);
             }
         };
 
@@ -1167,16 +1155,12 @@
                 var node = doc.createElement('script');
 
                 // check if it's an external source
-                ext = source.indexOf('//') > -1;
+                if ((ext = source.indexOf('//') > -1)) {
+                    node.onload = extDepLoaded(source)
+                }
 
                 // create module script url
-                url = '/@/Z/M/' + source;
-
-                // handle external scripts onload event
-                if (source[0] === '/' || ext) {
-                    node.onload = extDepLoaded(source);
-                    url = source;
-                }
+                url = source[0] === '/' ? source : '/@/Z/M/' + source;
 
                 // add fingerprint to the url
                 node.src = ext ? url : url.replace(/\.js$/, '.' + fingerprint + '.js');

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -11,7 +11,8 @@ var cache = require(env.Z_PATH_CACHE + 'cache');
 // init caches
 var compInstances = cache.comp('instances');
 var compModules = cache.comp('modules');
-var fileClient = cache.file('client');
+var fileModule = cache.file('module', {wd: env.Z_PATH_PROCESS_MODULES});
+var fileClient = cache.file('client', {wd: env.Z_PATH_CLIENT, noWrap: true});
 
 module.exports = init;
 
@@ -223,11 +224,15 @@ function instanceFactory (name, module, compInst, callback) {
             compInstances.pojo.set(compInst.name, instance);
         }
 
+        // configure client main file
+        if (module.clientMain) {
+            instance._client.main = module.clientMain;
+        }
+
         // save instance in cache
-        // TODO update this cache when a instance config changes
         compInstances.pojo.set(name, instance);
 
-        // require and init mono module
+        // require and init module
         if (module.main) {
 
             try {
@@ -409,10 +414,10 @@ function moduleFiles (req, res) {
             }
 
             // save compressed/compiled script in cache and send it to the client
-            fileClient.set(
+            fileModule.set(
 
                 // create absolute file path
-                env.Z_PATH_PROCESS_MODULES + self.link.path.join('/'),
+                self.link.path.slice(4).join('/'),
 
                 // callback
                 function (err, script) {
@@ -425,11 +430,13 @@ function moduleFiles (req, res) {
 
                     res.writeHead(200, script.http);
                     res.end(script.data);
-                    return;
                 },
 
-                // pass module composition and path
-                {deps: module.dependencies, path: self.link.path}
+                // pass an array of allowed files
+                module.dependencies,
+
+                // prepend module path to the requested file
+                self.link.path.slice(0, 4).join('/') + '/'
             );
         }
     );
@@ -440,7 +447,7 @@ function client (req, res) {
     var self = this;
 
     // save compressed/compiled script in cache and send it to the client
-    fileClient.set(env.Z_PATH_CLIENT + self.link.path[0], function (err, script) {
+    fileClient.set(self.link.path[0], function (err, script) {
 
         if (err) {
             res.writeHead(500, {'content-type': 'text/plain'});
@@ -450,6 +457,5 @@ function client (req, res) {
 
         res.writeHead(200, script.http);
         res.end(script.data);
-        return;
     });
 }

--- a/lib/module/module.js
+++ b/lib/module/module.js
@@ -122,7 +122,7 @@ function instanceFactory (name, module, compInst, callback) {
 
     // create new Mono observer instance
     var instance = new EventEmitter();
-    instance._module = module.name.replace(/_/g, '/') + '/';
+    instance._module = module.name ? module.name.replace(/_/g, '/') + '/' : '';
     instance._name = compInst.name;
     instance._access = {};
     instance._roles = compInst.roles || {};
@@ -236,7 +236,10 @@ function instanceFactory (name, module, compInst, callback) {
         if (module.main) {
 
             try {
-                var monoModule = require(env.Z_PATH_PROCESS_MODULES + instance._module + module.main);
+
+                // get absolute path from the repo and relative path from the module
+                var path = module.main[0] === '/' ? env.Z_PATH_PROCESS_REPO : env.Z_PATH_PROCESS_MODULES + instance._module;
+                var monoModule = require(path + module.main);
 
                 if (typeof monoModule === 'function') {
                     monoModule.call(instance, instance._config || {}, function (err) {
@@ -289,6 +292,11 @@ function loadinstance (name, role, callback) {
         // check access
         if (!instance) {
             return callback(new Error('Instance ' + name + ' not found.'));
+        }
+
+        // don't get a module if the instance is a custom module
+        if (typeof instance.module === 'object') {
+            return instanceFactory(name, instance.module, instance, callback);
         }
 
         compModules.get(instance.module, role, function (err, module) {

--- a/lib/project/router.js
+++ b/lib/project/router.js
@@ -12,7 +12,7 @@ var resHeaders = {
     'Content-Encoding': 'gzip'
 };
 
-var publicCache = cache.file('public');
+var publicCache = cache.file('public', {wd: env.Z_PATH_PROCESS_PUBLIC});
 
 // get libs array
 function getLibs (callback) {
@@ -102,7 +102,7 @@ function route (pathname, req, res) {
         return sendClient(res, req._sidInvalid);
     }
 
-    publicCache.set(env.Z_PATH_PROCESS_PUBLIC + pathname.substr(1), function (err, file) {
+    publicCache.set(pathname, function (err, file) {
 
         if (err) {
 

--- a/lib/views/factory.js
+++ b/lib/views/factory.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var cache = require(env.Z_PATH_CACHE + 'cache');
 var fingerprint = require(env.Z_PATH_UTILS + 'fingerprint');
 var compViews = cache.comp('views');
-var snippetCache = cache.file('snippets', true);
+var snippetCache = cache.file('snippets', {wd: env.Z_PATH_PROCESS_MARKUP, noCompression: true});
 
 module.exports = factoryService;
 
@@ -53,7 +53,7 @@ function factory (name, role, callback) {
                 return callback(null, view);
             }
 
-            var path = env.Z_PATH_PROCESS_MARKUP + view.html.replace(/[^a-z0-9\/\.\-_]|\.\.\//gi, '');
+            var path = view.html.replace(/[^a-z0-9\/\.\-_]|\.\.\//gi, '');
             snippetCache.set(path, function (err, snipped) {
 
                 if (err) {


### PR DESCRIPTION
Now all client script files in a repo are wrapped in a CommonJS module and modules can also `require` the absolute dependencies. Following benefits come from default wrapping client script files:
- The order of when a script is evaluated can be controlled.
- Custom module scripts can be written in the same way as "normal" module scripts.
- The possibility to use different versions of the same library (ex. jQuery)
- Libraries which are dependent on a global also work
