### PR TITLE
Append DOM data to events

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -854,6 +854,7 @@
                 var data;
                 var to;
                 var _path;
+                var _domElm;
 
                 for (i = 0; i < config.emit.length; ++i) {
 
@@ -894,10 +895,29 @@
 
                         // add data to the data object
                         for (key in emit.add) {
-                            _path = emit.add[key].replace(find_index, '.' + (elmIndex || 0));
 
-                            // update data object
-                            data[key] = self._path(_path) || self._path(_path, data, true);
+                            // get an attribute value from a dom element or the element itself
+                            if (emit.add[key][0] === '$') {
+                                _domElm = emit.add[key].substr(1).split(':');
+                                _domElm[0] = doc.querySelector(_domElm[0]);
+
+                                // get an attribute
+                                if (_domElm[1]) {
+                                    _domElm[1] = _domElm[0][_domElm[1]];
+                                }
+
+                                // add dom attribute value or the element itself
+                                data[key] = _domElm[1] === undefined ? _domElm[0] : _domElm[1];
+
+                            // extend data with keys from an other object
+                            } else {
+
+                                // replace positional operator with index number
+                                _path = emit.add[key].replace(find_index, '.' + (elmIndex || 0));
+
+                                // update data object
+                                data[key] = self._path(_path) || self._path(_path, data, true);
+                            }
                         }
 
                         // create deep object out of flat keys


### PR DESCRIPTION
Append a DOM element or an attribute value of the selected DOM element.
Exaple config:

``` json
"A": {
   "emit": [
        {
            "event": "myEvent",
            "add": {
                 "key": "$#selector:attribute",
                 "password": "$input[type=password]:value"
            }
        }
    ]
}
```

If the string starts with an `$`, then engine tries to find the DOM element. All css selectors are supported. The attribute name is specified after the colon char.

`$[css-selector]:[attribute-name]`
