### PR TITLE
Instance name is no longer a part of a view

### DIFF
--- a/lib/views/factory.js
+++ b/lib/views/factory.js
@@ -96,7 +96,7 @@ function factoryService (err, name, callback) {
 
         // create client view
         var clientView = {
-            name: view.name.split('_').pop()
+            name: view.name
         };
 
         // add client config


### PR DESCRIPTION
View names are no longer namespaced. Some modules have checks if an particular `view` name exists. Those modules must handle `views` dynamic, otherwise a `view` name would be hard-coded in the module.
