### PR TITLE
Nested views

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -535,6 +535,9 @@
             // save observer action config for later use after rendering
             view.flow = config.flow;
 
+            // add infos for nested views
+            view.nested = config.nested;
+
             // save view in instance
             self.view[config.name] = view;
 
@@ -979,7 +982,25 @@
         str = key.indexOf('.') > 0 ? Z._path(key, data) : data[key];
 
         // if str is null or undefined
-        str = (str == null ? (leaveKeys ? key : '') : str) + '';
+        str = str == null ? (leaveKeys ? key : '') : str;
+
+        // render a nested view
+        if (typeof str === 'object' && this.nested && this._.view[this.nested[key]]) {
+            var view = this._.view[this.nested[key]];
+
+            // render nested view and don't append to the dom
+            view.render(str, dont_escape_html, leaveKeys, true);
+
+            // get html of rendered view
+            str = view.html;
+
+            // don't escape html chars
+            dont_escape_html = true;
+
+        // make sure str is a string
+        } else {
+            str += '';
+        }
 
         // escape html chars
         if (!dont_escape_html) {
@@ -997,7 +1018,7 @@
         return new Function("_", "f", "e", "k", "_=_||{};return '" +
             (tmpl || '').replace(/[\\\n\r']/g, function(_char) {
                 return template_escape[_char];
-            }).replace(/{\s*([\w\.]+)\s*}/g, "' + f(_,'$1',e,k) + '") + "'"
+            }).replace(/{\s*([\w\.]+)\s*}/g, "' + f.call(this,_,'$1',e,k) + '") + "'"
         );
     }
 

--- a/lib/views/factory.js
+++ b/lib/views/factory.js
@@ -104,6 +104,10 @@ function factoryService (event, name, callback) {
             clientView.config = view.config.client;
         }
 
+        if (view.nested) {
+            clientView.nested = view.nested;
+        }
+
         if (view.flow) {
             clientView.flow = view.flow;
         }


### PR DESCRIPTION
A `view` can now have a `nested` view.

Imagine you have a list of articles and every article has a list of colors.
Naturally you have a data object:

``` json
[{
    "name": "Article Name",
    "colors": [{
        "code": "#RGB",
        "price": "35.20"
    }]
}]
```

And a HTML:

``` html
<div id="article">
    <h1>{name}</h1>
    <ul>
        <li style="background-color:{code}">
            Price: {price}
        </li>
    </ul>
</div>
```

But since the number of colors is dynamic, the HTML must generated.

This is now possible by defining `nested` views.
View with `nested` config:

``` json
{
    "name": "article_list_item",
    "html": "article_item.html",
    "to": "#selector",
    "nested": {
        "colors": "color_list_item"
    }
}
```

Nested view:

``` json
{
    "name": "color_list_item",
    "html": "color_item.html",
    "nested": {
        "nesting_is_recursive": "..."
    }
}
```

The `nested.colors` defines on which property, in the `data` object, the specified `view` is loaded.
So with the above config you could render following data:

``` json
[{
    "name": "Article Name",
    "colors": [{
        "code": "#RGB",
        "price": "35.20"
    }]
}]
```

The `article_list_item` HTML:

``` html
<div id="article">
    <h1>{name}</h1>
    <ul>{colors}</ul>
</div>
```

And the `color_list_item` HTML:

``` html
<li style="background-color:{code}">
    Price: {price}
</li>
```

Result HTML:

``` html
<div id="article">
    <h1>Article Name</h1>
    <ul>
        <li style="background-color:#RGB">
            Price: 35.20
        </li>
    </ul>
</div>
```
