### PR TITLE
Flow scope

### DIFF
--- a/lib/client/Z.js
+++ b/lib/client/Z.js
@@ -436,7 +436,7 @@
 
                 // append dom events
                 if (self.flow) {
-                    flow.call(self._, self.flow, true);
+                    flow.call(self._, self.flow, false, self, self.dom, self.data);
                 }
 
                 // change html before writing it to the dom
@@ -447,12 +447,11 @@
 
             // set a template function or a html snippet
             set: function (html, dom, scope) {
-                var self = this;
 
                 // create template function
-                self.tpl = createTemplate(html);
-                self.scope = scope;
-                self.dom = dom;
+                this.tpl = createTemplate(html);
+                this.scope = scope;
+                this.dom = dom;
             }
         },
 
@@ -635,7 +634,7 @@
 
             // set up ovserve configs from views and modules
             if (!init[0]) {
-                flow.call(init[1], init[2], false, true);
+                flow.call(init[1], init[2], true);
                 return initConstructorsHandler(constructors[++count]);
             }
 
@@ -730,11 +729,17 @@
     }
 
     // set up event flow
-    function flow (config, onlyDom, onlyObs) {
+    function flow (config, onlyObs, onlyDom, domScope, data) {
         var self = this;
-        var i, e;
+        var i, e, s;
         var elms;
         var flow;
+        var scope = [domScope];
+
+        // set children as scope if there is more then one data item
+        if (domScope && data.length > 1 && domScope.children) {
+            scope = domScope.children;
+        }
 
         for (i = 0; i < config.length; ++i) {
             flow = config[i];
@@ -742,20 +747,34 @@
             // handle dom event
             if (flow.selector && !onlyObs) {
 
-                elms = doc.querySelectorAll(flow.selector);
-                if (elms) {
-                    for (e = 0; e < elms.length; ++e) {
-                        elms[e].addEventListener(
-                            flow['in'],
-                            createHandler.call(
-                                self,
-                                flow.out,
-                                true,
-                                e,
-                                elms,
-                                flow.dontPrevent
-                            )
-                        );
+                // overwrite scope with the document
+                if (flow.scope == 'global') {
+                    scope = [doc];
+                }
+
+                // overwrite scope with parent
+                if (flow.scope == 'parent') {
+                    scope = [domScope];
+                }
+
+                for (s = 0; s < scope.length; ++s) {
+
+                    elms = scope[s].querySelectorAll(flow.selector);
+                    if (elms) {
+                        for (e = 0; e < elms.length; ++e) {
+
+                            elms[e].addEventListener(
+                                flow['in'],
+                                createHandler.call(
+                                    self,
+                                    flow.out,
+                                    scope[s],
+                                    data[s],
+                                    elms,
+                                    flow.dontPrevent
+                                )
+                            );
+                        }
                     }
                 }
 
@@ -772,35 +791,37 @@
         }
     }
 
-    // act (handlers)
-    function createHandler (outConfig, dom, elmIndex, elms, dontPrevent) {
+    // createHandler
+    function createHandler (outConfig, domScope, dataItem, elms, dontPrevent) {
         var self = this;
-        var callback = function () {};
         var i, call;
+        var callback = function (event, eventHandler, errorHandler) {
+
+            if (!eventHandler && !errorHandler) {
+                return function () {};
+            }
+
+            return function (err, data) {
+
+                if (err) {
+                    event.error = err;
+                    (errorHandler || eventHandler).call(self, event, data);
+
+                } else if (eventHandler) {
+                    eventHandler.call(self, event, data);
+                }
+            };
+        };
 
         // handle call stdOut and stdErr configuration
-        for (var i = 0; i < outConfig.length; ++i) {
-            if ((call = outConfig[i].call) && call[1]) {
+        for (i = 0; i < outConfig.length; ++i) {
 
-                var errorHandler;
-                var handler = createHandler.call(self, call[1], dom, elmIndex, elms, dontPrevent);
+            if ((call = outConfig[i].call) && call[1] && typeof call[1] !== fn) {
+
+                call[1] = createHandler.call(self, call[1], domScope, dataItem, elms, dontPrevent);
 
                 if (call[2]) {
-                    errorHandler = createHandler.call(self, call[2], dom, elmIndex, elms, dontPrevent);
-                }
-
-                // create callback handler
-                if (handler || errorHandler) {
-                    callback = function (err, data) {
-
-                        if (err) {
-                            event.error = err;
-                            (errorHandler || handler).call(self, event, data);
-
-                        } else if (handler) {
-                            handler.call(self, event, data);
-                        }
-                    }
+                    call[2] = createHandler.call(self, call[2], domScope, dataItem, elms, dontPrevent);
                 }
             }
         }
@@ -821,7 +842,10 @@
             event.ori = event.ori || self._name;
 
             // extend dom event object
-            if (dom) {
+            if (domScope) {
+
+                // add dom scope to event
+                event._scope = event._scope || domScope;
 
                 // dont prevent default browser actions
                 if (!dontPrevent) {
@@ -829,10 +853,10 @@
                 }
 
                 // add found elements to event
-                event.elms = elms;
+                event._elms = elms;
 
                 // add index of found elements
-                event.index = elmIndex;
+                event._item = event._item || dataItem;
             }
 
             // add pathname to data object
@@ -883,6 +907,8 @@
                         // get an attribute value from a dom element or the element itself
                         if (path[0] === '$') {
                             _domElm = path.substr(1).split(':');
+
+                            // TODO global scope should also be an option
                             _domElm[0] = doc.querySelector(_domElm[0]);
 
                             // get an attribute
@@ -893,13 +919,8 @@
                             // add dom attribute value or the element itself
                             data[key] = _domElm[1] === undefined ? _domElm[0] : _domElm[1];
 
-                        // extend data with keys from an other object
+                        // get search value with a path: 1. events, 2. data, 3. instance, 4. window
                         } else {
-
-                            // replace positional operator with index number
-                            path = path.replace(find_index, '.' + (elmIndex || 0));
-
-                            // update data object
                             data[key] = self._path(path, event, true) || self._path(path, data, true) || self._path(path);
                         }
                     }
@@ -932,7 +953,7 @@
                     }
 
                     // call method
-                    config.call[0].call(eSelf, event, data, callback);
+                    config.call[0].call(eSelf, event, data, callback(event, config.call[1], config.call[2]));
                 }
             }
 


### PR DESCRIPTION
A `selector` in a `out` config of an `flow` object (aka. `actions`), have now by default, the `view` DOM as the scope, for searching the element specified in the `selector`. That means if render a list, you will have always the current item as scope. Further the `data` object, which is used to render a `view` is now also easily accessible under the `_item` key in the event. Thus it's now possible to write some thing like this:

``` json
"flow": [
    {
        "selector": ".someSelector",
        "in": "click",
        "out": [
            {
                "call": [
                    "awesom.method",
                    [{
                        "emit": "okLetsDoMore"}],
                    [{
                        "emit": "OOH!_error"
                    }]
                ],
                "to": "superModule",
                "set": {
                    "someKey": "_item.some.value"
                }
            }
        ]
    }
]
```

That means, if `.someSelector` is inside a list, I will be very hard to select the item of the clicked `selector`. With scoping this is done by default.

If you need to select DOM in a global space then you can use the new options `scope: "parent"` or `scope: "global"`. `parent` means the DOM, which the view was rendered to. And `global` means, the hole `document`.

Example:

``` json
"flow": [
    {
        "selector": ".someSelector",
        "scope": "parent | global",
        "in": "click",
        "out": []
    }
]
```
