### PR TITLE
Module specifc flow

### DIFF
--- a/lib/comp.js
+++ b/lib/comp.js
@@ -113,15 +113,16 @@ module.exports = function (name, role, callback) {
                         composition._server = modulePackage._base + modulePackage.main;
                     }
 
+                    // default module package flow configuration
+                    modulePackage.flow = modulePackage.flow || [];
+                    modulePackage.clientFlow = modulePackage.clientFlow || [];
+
                     // create the server flow
                     composition.flow = composition.flow || [];
                     composition.flow = composition.flow.concat(modulePackage.flow);
 
                     // create the client flow
-                    composition.client.flow = composition.client || [];
-                    if (!composition.client.flow.concat) {
-                        debugger
-                    }
+                    composition.client.flow = composition.client.flow || [];
                     composition.client.flow = composition.client.flow.concat(modulePackage.clientFlow);
 
                     // create a new module instance

--- a/lib/comp.js
+++ b/lib/comp.js
@@ -113,6 +113,17 @@ module.exports = function (name, role, callback) {
                         composition._server = modulePackage._base + modulePackage.main;
                     }
 
+                    // create the server flow
+                    composition.flow = composition.flow || [];
+                    composition.flow = composition.flow.concat(modulePackage.flow);
+
+                    // create the client flow
+                    composition.client.flow = composition.client || [];
+                    if (!composition.client.flow.concat) {
+                        debugger
+                    }
+                    composition.client.flow = composition.client.flow.concat(modulePackage.clientFlow);
+
                     // create a new module instance
                     module_instance = engine.module.factory(composition);
 


### PR DESCRIPTION
Now we can configure `flow` and `clientFlow` in `package.json`.

Example: https://github.com/jillix/builder/blob/144e379f5ee4665e0535b30224add07cbf91394e/package.json#L26-L56

Fixes #175.
