### PR TITLE
Random fixes in the flow configuration

### DIFF
--- a/lib/client/engine.js
+++ b/lib/client/engine.js
@@ -42,10 +42,10 @@
         on: on,
         off: off
     };
-    
+
     // client flag
     engine.client = true;
-    
+
     // default config
     engine._module = '@';
 
@@ -146,7 +146,7 @@
             if (_event === event || events[_event].re.test(event)) {
 
                 // call handlers
-                for (var i = 0; i < events[_event].length; ++i) {
+                for (var i = 0, l = events[_event].length; i < l; ++i) {
                     if (events[_event][i]) {
 
                         // call registered Methods
@@ -367,13 +367,13 @@
 
             // complete url and clean path
             url = (url[0] === '/' || url.indexOf('://') > 0 ? '' : '/@/@/') + url;
-            
+
             // remove public file identifier
             cleanPath = isPublicPath.test(cleanPath) ? cleanPath.substr(2) : cleanPath;
-            
+
             // overwrite script path with path without fingerprints
             scripts[i] = cleanPath;
-            
+
             // when script is loaded check if it's evaluated
             engine.on('^' + cleanPath + '$', modDepLoaded, 1);
 

--- a/lib/client/engine.js
+++ b/lib/client/engine.js
@@ -150,7 +150,7 @@
                     if (events[_event][i]) {
 
                         // call registered Methods
-                        events[_event][i].apply(self, args);
+                        events[_event][i].apply(instance, args);
 
                         // remove from event buffer, if once is true
                         if (events[_event][i]._1) {
@@ -251,7 +251,7 @@
             for (i = 0; i < rmObject.length; ++i) {
 
                 // remove handler
-                events[rmObject[i][0]].splice(rmObject[i][0], 1);
+                events[rmObject[i][0]].splice(rmObject[i][1], 1);
 
                 // remove event
                 if (events[rmObject[i][0]].length === 0) {


### PR DESCRIPTION
- Save the length of the handlers array before running the `for` loop.
- Use the `instance` variable to call the handlers instead of `self` (which was being the `window`).
- Pass the index value in the `splice` call instead of the event name.

Fixes #189.
