### PR TITLE
Load shared or dedicated workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A composition config, configures an instance of a module.
 }
 ```
 ##### Custom module:
-Custom modules are create by providing the `composition` part of a module package, to the `module` key.
+Custom modules are created by providing the `composition` part of a module package, to the `module` key.
 Expect the `client.dependencies` key is not supported, cause the client dependencies are dependent on installed 
 modules and custom modules cannot install other modules.
 ```json

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Extend the `npm` `package.json` with a `composition` object, to define a default
         "config": {},
         "flow": [{}],
         "client": {
-            "module": [
-                "module/script.js",
-                "/public/repo/script.js",
-                "//external/script.js"
+        "module": [
+                  "module/script.js",
+                  "/public/repo/script.js",
+                  "//external/script.js"
             ],
             "dependencies": ["module"],
             "config": {},
@@ -79,6 +79,29 @@ A composition config, configures an instance of a module.
             "styles": ["/path/file.css"],
             "markup": ["/path/file.html"]
       }
+}
+```
+##### Custom module:
+Custom modules are create by providing the `composition` part of a module package, to the `module` key.
+Expect the `client.dependencies` key is not supported, cause the client dependencies are dependent on installed 
+modules and custom modules cannot install other modules.
+```json
+{
+      "module": {
+            "public": "public/folder",
+            "config": {},
+            "flow": [{}],
+            "client": {
+                  "module": [
+                        "/public/repo/script.js",
+                        "//external/script.js"
+                  ],
+                  "config": {},
+                  "flow": [{}],
+                  "styles": ["styles.css"],
+                  "markup": ["markup.html"]
+            }
+      },
 }
 ```
 #####Flow:

--- a/README.md
+++ b/README.md
@@ -88,17 +88,18 @@ modules and custom modules cannot install other modules.
 ```json
 {
     "module": {
+        "main": "folder/in/repo/index.js",
         "public": "public/folder",
         "config": {},
         "flow": [{}],
         "client": {
             "module": [
-                "/public/repo/script.js",
+                "/public/script.js",
                 "//external/script.js"
             ],
             "config": {},
             "flow": [{}],
-            "styles": ["styles.css"],
+            "styles": ["/public/styles.css"],
             "markup": ["markup.html"]
         }
     }

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Extend the `npm` `package.json` with a `composition` object, to define a default
         "config": {},
         "flow": [{}],
         "client": {
-        "module": [
-                  "module/script.js",
-                  "/public/repo/script.js",
-                  "//external/script.js"
+            "module": [
+                "module/script.js",
+                "/public/repo/script.js",
+                "//external/script.js"
             ],
             "dependencies": ["module"],
             "config": {},
@@ -66,19 +66,19 @@ Extend the `npm` `package.json` with a `composition` object, to define a default
 A composition config, configures an instance of a module.
 ```json
 {
-      "roles": {"*": true},
-      "name": "instance",
-      "module": "module",
-      "config": {},
-      "flow": [{}],
-      "load": ["instance"],
-      "client": {
-            "config": {},
-            "flow": [{}],
-            "load": ["instance"],
-            "styles": ["/path/file.css"],
-            "markup": ["/path/file.html"]
-      }
+    "roles": {"*": true},
+    "name": "instance",
+    "module": "module",
+    "config": {},
+    "flow": [{}],
+    "load": ["instance"],
+    "client": {
+        "config": {},
+        "flow": [{}],
+        "load": ["instance"],
+        "styles": ["/path/file.css"],
+        "markup": ["/path/file.html"]
+    }
 }
 ```
 ##### Custom module:
@@ -87,33 +87,33 @@ Expect the `client.dependencies` key is not supported, cause the client dependen
 modules and custom modules cannot install other modules.
 ```json
 {
-      "module": {
-            "public": "public/folder",
+    "module": {
+        "public": "public/folder",
+        "config": {},
+        "flow": [{}],
+        "client": {
+            "module": [
+                "/public/repo/script.js",
+                "//external/script.js"
+            ],
             "config": {},
             "flow": [{}],
-            "client": {
-                  "module": [
-                        "/public/repo/script.js",
-                        "//external/script.js"
-                  ],
-                  "config": {},
-                  "flow": [{}],
-                  "styles": ["styles.css"],
-                  "markup": ["markup.html"]
-            }
-      },
+            "styles": ["styles.css"],
+            "markup": ["markup.html"]
+        }
+    }
 }
 ```
 #####Flow:
 Flow configs create streams, that allow to send and receive data from a module instance method.
 ```json
 {
-      "on": "event",
-      "1": false,
-      "to": "instance",
-      "emit": "event",
-      "call": "path|instance/event|ws://domain.com/instance/event",
-      "data": ["path", {}]
+    "on": "event",
+    "1": false,
+    "to": "instance",
+    "emit": "event",
+    "call": "path|instance/event|ws://domain.com/instance/event",
+    "data": ["path", {}]
 }
 ```
 Flow's `call` can now emit server side events, by providing a URL: `ws://domain.com/instance/event`. This will pipe the event stream to a websocket stream, which is emitted on the server side. If the domain is not part of the URL: `instance/event` engine uses the current client host.

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -92,6 +92,11 @@ var Cache = {
 
         if (key) {
             this._data[key] = data;
+            
+            // save item ref also with cache alias
+            if (data._cache_alias) {
+                this._data[data._cache_alias] = data;
+            }
         }
     }
 };

--- a/lib/client/flow.js
+++ b/lib/client/flow.js
@@ -38,7 +38,7 @@ var FlowEmitter = {
         
         // setup event stream directly if eventName is an object
         if (eventName && eventName.on) {
-            Flow.call(this, stream, eventName, context);
+            Flow(this, stream, eventName, context);
             return stream;
         }
         
@@ -55,7 +55,7 @@ var FlowEmitter = {
                 if ((config = events[eventName][i])) {
                     
                     // pass stream to flow to setup handlers
-                    Flow.call(this, stream, config, context);
+                    Flow(this, stream, config, context);
                     
                     // remove from event buffer, if once is true
                     if (config['1']) {
@@ -113,8 +113,7 @@ var FlowEmitter = {
  * @param {object} The "out" config.
  * @param {object} The adapter object (optional).
  */
-function Flow (originStream, config, context) {
-    var instance = this;
+function Flow (instance, originStream, config, context) {
     var session = originStream.session;
     var role = (session || {})[engine.session_role];
     

--- a/lib/client/flow.js
+++ b/lib/client/flow.js
@@ -191,11 +191,13 @@ function getMethodFromPath (path, module_instance) {
     if (typeof path === 'function') {
         return path;
     }
+    
+    var _path = path;
     if (
         typeof path === 'string' &&
         typeof (path = utils.path(path, [engine.handlers, module_instance, global])) !== 'function'
     ) {
-        console.error('Flow method is not a function.');
+        console.error('Flow method "' + _path + '" is not a function. Instance:' + module_instance._name);
         return;
     }
     

--- a/lib/client/flow.js
+++ b/lib/client/flow.js
@@ -149,11 +149,11 @@ function Flow (instance, originStream, config, context) {
 }
 
 function createAndSetupStream (instance, originStream, config, context) {
-
+    
     // create a duplex stream for every event
     var stream = Stream(instance, context);
     
-    // pipe duplex streams in both directions
+    // pipe streams in both directions (duplex)
     stream.pipe(originStream).pipe(stream);
     
     // add data handler to stream
@@ -163,10 +163,10 @@ function createAndSetupStream (instance, originStream, config, context) {
     ) {
         stream.data(config.data[0], config.data[1]);
     }
-
+    
     // emit stream to other flow handlers
     if (typeof config.emit === 'string') {
-        instance.flow(config.emit, null, stream);
+        instance.flow(config.emit, null, originStream);
     }
 
     // pass stream to receiver function

--- a/lib/client/resource.js
+++ b/lib/client/resource.js
@@ -101,7 +101,7 @@ function load (scripts, callback) {
         scripts[i] = cleanPath;
 
         // emit source event for already loaded scripts
-        if (moduleCache[cleanPath] && moduleCache[cleanPath][0] !== moduleLoaded) {
+        if (moduleCache[cleanPath] && moduleCache[cleanPath]._eval) {
             moduleLoaded();
 
         // load module scripts

--- a/lib/client/resource.js
+++ b/lib/client/resource.js
@@ -8,18 +8,18 @@
  * @param {function} The wrapper function, which returns the module object
  */
 var engine = global.E = function Engine (path, module) {
-    
+
     // create CommonJS module directly if path is not loaded from a dependency list.
     if (!moduleCache[path]) {
         moduleCache[path] = module;
         createCommonJSModule(path);
-    
+
     // emit path as event to create CommonJS modules in order,
     // after all resources are loaded.
     } else {
         var checkLoaded = moduleCache[path];
         moduleCache[path] = module;
-        
+
         // call all load handlers
         for (var i = 0, l = checkLoaded.length; i < l; ++i) {
             checkLoaded[i]();
@@ -61,16 +61,16 @@ function load (scripts, callback) {
     for (var i = length - 1, url, cleanPath, worker; i >= 0; --i) {
 
         url = scripts[i];
-        
+
         // get worker info
         worker = false;
         if (isWorker.test(url)) {
             worker = url.substr(1,1);
             url = url.substr(3);
         }
-        
+
         cleanPath = url;
-        
+
         if (checkFp.test(url)) {
 
             // split path
@@ -106,14 +106,15 @@ function load (scripts, callback) {
 
         // load module scripts
         } else if (!moduleCache[cleanPath]) {
-            
+
             // load a shared or dedicated worker
             if (worker) {
                 moduleCache[cleanPath] = worker === 'S' ? new SharedWorker(url) : new Worker(url);
+                moduleCache[cleanPath]._eval = true;
                 moduleLoaded();
                 continue;
             }
-            
+
             // create script cache entry
             moduleCache[cleanPath] = [moduleLoaded];
 
@@ -123,7 +124,7 @@ function load (scripts, callback) {
             // set url and append dom script elm to the document head
             node.src = url;
             body.head.appendChild(node);
-        
+
         // push load handler method
         } else {
             moduleCache[cleanPath].push(moduleLoaded);
@@ -159,7 +160,7 @@ function evaluateScriptsInOrder (scripts, callback) {
  * @param {string} The script path.
  */
 function createCommonJSModule(script) {
-    
+
     var module = {
         id: script,
         exports: {}
@@ -215,12 +216,12 @@ function getNearestModulePath (module, name) {
  */
 function require (module) {
     return function (name, callback) {
-        
+
         // load a module resources and create a CommonJS module
         if (name instanceof Array) {
             return load(name, callback);
         }
-        
+
         // handle different path types
         switch (name.indexOf('./')) {
 

--- a/lib/client/resource.js
+++ b/lib/client/resource.js
@@ -60,8 +60,17 @@ function load (scripts, callback) {
     // loop through scripts
     for (var i = length - 1, url, cleanPath, worker; i >= 0; --i) {
 
-        url = cleanPath = scripts[i];
-
+        url = scripts[i];
+        
+        // get worker info
+        worker = false;
+        if (isWorker.test(url)) {
+            worker = url.substr(1,1);
+            url = url.substr(3);
+        }
+        
+        cleanPath = url;
+        
         if (checkFp.test(url)) {
 
             // split path
@@ -73,25 +82,18 @@ function load (scripts, callback) {
             // create path without fingerprint
             cleanPath = cleanPath.join('.');
         }
-        
-        // get worker info
-        worker = false;
-        if (isWorker.test(url)) {
-            worker = url.substr(1,1);
-            url = url.substr(3);
-        }
 
         // append public file prefix
         if (isPublicPath.test(cleanPath)) {
-            url = '/!' + url + '?w=1';
+            url = '/!' + url + (worker ? '' : '?w=1');
 
         // append module file prefix
         } else if (url.indexOf('://') < 0 && url.indexOf('//') !== 0) {
-            url = '/@/@/' + url + '?w=1';
+            url = '/@/@/' + url + (worker ? '' : '?w=1');
 
         // handle external files, that must be wrapped
         } else if (url[0] === '#') {
-            url = '/@/@/!/' + url.substr(1) + '?w=1';
+            url = '/@/@/!/' + url.substr(1) + (worker ? '' : '?w=1');
             cleanPath = cleanPath.substr(1);
         }
 
@@ -108,7 +110,8 @@ function load (scripts, callback) {
             // load a shared or dedicated worker
             if (worker) {
                 moduleCache[cleanPath] = worker === 'S' ? new SharedWorker(url) : new Worker(url);
-                return moduleLoaded();
+                moduleLoaded();
+                continue;
             }
             
             // create script cache entry
@@ -253,7 +256,7 @@ function require (module) {
         name += name.slice(-3) !== '.js' ? '.js' : '';
 
         if (moduleCache[name]) {
-            return moduleCache[name].exports;
+            return moduleCache[name].exports || moduleCache[name];
         }
     };
 }

--- a/lib/client/resource.js
+++ b/lib/client/resource.js
@@ -32,6 +32,7 @@ var moduleCache = {};
 
 // constants
 var isPublicPath = /^\/[^/]/;
+var isWorker = /^\(W|S\)/;
 var checkFp = /\.@[a-z0-9]{7}\.(?:js|css|html)$/i;
 
 /**
@@ -57,7 +58,7 @@ function load (scripts, callback) {
     }
 
     // loop through scripts
-    for (var i = length - 1, url, cleanPath; i >= 0; --i) {
+    for (var i = length - 1, url, cleanPath, worker; i >= 0; --i) {
 
         url = cleanPath = scripts[i];
 
@@ -71,6 +72,13 @@ function load (scripts, callback) {
 
             // create path without fingerprint
             cleanPath = cleanPath.join('.');
+        }
+        
+        // get worker info
+        worker = false;
+        if (isWorker.test(url)) {
+            worker = url.substr(1,1);
+            url = url.substr(3);
         }
 
         // append public file prefix
@@ -96,7 +104,13 @@ function load (scripts, callback) {
 
         // load module scripts
         } else if (!moduleCache[cleanPath]) {
-
+            
+            // load a shared or dedicated worker
+            if (worker) {
+                moduleCache[cleanPath] = worker === 'S' ? new SharedWorker(url) : new Worker(url);
+                return moduleLoaded();
+            }
+            
             // create script cache entry
             moduleCache[cleanPath] = [moduleLoaded];
 

--- a/lib/client/stream.js
+++ b/lib/client/stream.js
@@ -36,6 +36,12 @@ var Stream = {
     
     // send data
     write: function (err, data) {
+        
+        // buffer data in paused mode
+        if (this._p) {
+            this._b.push([err, data]);
+            return this;
+        }
 
         var newData;
         
@@ -54,12 +60,6 @@ var Stream = {
           
             // get ouputs input handlers
             stream = this._o[o];
-            
-            // buffer data in paused mode
-            if (stream._p) {
-                stream._b.push([err, data]);
-                continue;
-            }
             
             handlers = stream._h;
             
@@ -133,19 +133,8 @@ var Stream = {
 
         // write bufferd data
         if (this._b.length) {
-            for (var i = 0, l = this._b.length, err, data; i < l; ++i) {
-              
-                // TODO dont call write, call all output handlers instead
-                err = this._b[i][0];
-                data = this._b[i][1];
-                
-                // call data handlers with err and data as arguments
-                for (var h = 0, lh = this._h.length; h < lh; ++h) {
-                  
-                    // call data handler with stream instance as function scope
-                    // and overwrite data with transformed data
-                    data = this._h[h][0].call(stream._, err, data, stream, this._h[h][1]) || data;
-                }
+            for (var i = 0, l = this._b.length; i < l; ++i) {
+                this.write(this._b[i][0], this._b[i][1]);
             }
         }
 

--- a/lib/client/stream.js
+++ b/lib/client/stream.js
@@ -36,12 +36,6 @@ var Stream = {
     
     // send data
     write: function (err, data) {
-        
-        // buffer data in paused mode
-        if (this._p) {
-            this._b.push([err, data]);
-            return this;
-        }
 
         var newData;
         
@@ -60,6 +54,13 @@ var Stream = {
           
             // get ouputs input handlers
             stream = this._o[o];
+            
+            // buffer data in paused mode
+            if (stream._p) {
+                stream._b.push([err, data]);
+                continue;
+            }
+            
             handlers = stream._h;
             
             // call data handlers with err and data as arguments
@@ -132,8 +133,19 @@ var Stream = {
 
         // write bufferd data
         if (this._b.length) {
-            for (var i = 0, l = this._b.length; i < l; ++i) {
-                this.write(this._b[i][0], this._b[i][1]);
+            for (var i = 0, l = this._b.length, err, data; i < l; ++i) {
+              
+                // TODO dont call write, call all output handlers instead
+                err = this._b[i][0];
+                data = this._b[i][1];
+                
+                // call data handlers with err and data as arguments
+                for (var h = 0, lh = this._h.length; h < lh; ++h) {
+                  
+                    // call data handler with stream instance as function scope
+                    // and overwrite data with transformed data
+                    data = this._h[h][0].call(stream._, err, data, stream, this._h[h][1]) || data;
+                }
             }
         }
 

--- a/lib/client/stream.js
+++ b/lib/client/stream.js
@@ -43,16 +43,9 @@ var Stream = {
             return this;
         }
 
-        var newData;
-        
         // call custom write handler
         if (typeof this._write === 'function') {
-            newData = this._write(err, data, this);
-            
-            // overwrite data with transformed data
-            if (newData !== undefined) {
-                data = newData;
-            }
+            data = this._write(err, data, this) || data;
         }
         
         // call handlers on output streams
@@ -60,7 +53,6 @@ var Stream = {
           
             // get ouputs input handlers
             stream = this._o[o];
-            
             handlers = stream._h;
             
             // call data handlers with err and data as arguments
@@ -68,12 +60,7 @@ var Stream = {
               
                 // call data handler with stream instance as function scope
                 // and overwrite data with transformed data
-                newData = handlers[i][0].call(stream._, err, data, stream, handlers[i][1]);
-                
-                // overwrite data with transformed data
-                if (newData !== undefined) {
-                    data = newData;
-                }
+                data = handlers[i][0].call(stream._, err, data, stream, handlers[i][1]) || data;
             }
         }
 

--- a/lib/client/utils.js
+++ b/lib/client/utils.js
@@ -15,6 +15,20 @@ exports.clone = function (object) {
     // create new instance of empty function
     return new O();
 };
+
+exports.nextTick = function (fn) {
+    
+    var args = [].slice.apply(arguments);
+    
+    if (global.process) {
+        return process.nextTick.apply(this, args);
+    }
+    
+    // browser
+    setTimeout(function() {
+        fn.apply(this, args.slice(1));
+    }, 0);
+};
     
 /**
  * Get a value from a property "path" (dot.notation).

--- a/lib/composition.js
+++ b/lib/composition.js
@@ -43,11 +43,23 @@ module.exports = function (name, related, role, callback) {
   
         // ensure name
         config.name = config.name || name;
-
-        // merge related items to update cache on item change
-        if (related) {
-            config = File.relate(related, config);
+        
+        // ensure related config object
+        related = related || {};
+        related.compositions = related.compositions || {};
+        
+        // handle aliases for entrypoints
+        if (config.name !== name) {
+            config._cache_alias = engine.paths.app_composition + config.name + '.json';
+            related.instances[config.name] = true;
+            related.compositions[config._cache_alias] = true;
         }
+        
+        // merge related items to update cache on item change
+        config = File.relate(related, config);
+        
+        // add composition to related items
+        related.compositions[path] = true;
         
         // create mandatory package infos to custom module
         if (typeof config.module === 'object') {
@@ -62,17 +74,10 @@ module.exports = function (name, related, role, callback) {
                 config.module.main = config.module.composition.main;
                 delete config.module.composition.main;
             }
-        }
-        
-        // add composition to related items
-        related = related || {};
-        related.compositions = related.compositions || {};
-        related.compositions[path] = true;
-        
-        // set cache alias for entrypoints
-        if (config.name !== name) {
-            config._cache_alias = engine.paths.app_composition + config.name + '.json';
-            related.compositions[config._cache_alias] = true;
+            
+            // remove custom module on composition file change
+            related.modules = related.modules || {};
+            related.modules[config.module._id] = true;
         }
         
         Module(config.module, related, function (err, modulePackage) {

--- a/lib/composition.js
+++ b/lib/composition.js
@@ -53,6 +53,12 @@ module.exports = function (name, related, role, callback) {
             config.module.version = 'custom';
             config.module._id = name + '@custom';
             config.module._base = engine.repo;
+            
+            // move main out of the composition config
+            if (config.module.composition.main) {
+                config.module.main = config.module.composition.main;
+                delete config.module.composition.main;
+            }
         }
         
         // add composition to related items
@@ -66,6 +72,9 @@ module.exports = function (name, related, role, callback) {
             if (err) {
                 return callback(err);
             }
+            
+            // set packages server main in composition, to require server side module 
+            config._main = modulePackage.main;
             
             // prepare instance components
             if (config.client && (config.client.styles || config.client.markup)) {

--- a/lib/composition.js
+++ b/lib/composition.js
@@ -48,10 +48,11 @@ module.exports = function (name, related, role, callback) {
         
         // create mandatory package infos to custom module
         if (typeof config.module === 'object') {
+            config.module = {composition: config.module};
             config.module.name = name;
             config.module.version = 'custom';
             config.module._id = name + '@custom';
-            module._base = engine.repo;
+            config.module._base = engine.repo;
         }
         
         // add composition to related items

--- a/lib/composition.js
+++ b/lib/composition.js
@@ -40,7 +40,15 @@ module.exports = function (name, related, role, callback) {
         if ((err = err || checkComposition(name, path, role, config))) {
             return callback(err);
         }
-        
+  
+        // ensure name
+        config.name = config.name || name;
+
+        // set cache alias for entrypoints
+        if (config.name !== name) {
+            config._cache_alias = engine.paths.app_composition + config.name + '.json';
+        }
+
         // merge related items to update cache on item change
         if (related) {
             config = File.relate(related, config);
@@ -74,7 +82,9 @@ module.exports = function (name, related, role, callback) {
             }
             
             // set packages server main in composition, to require server side module 
-            config._main = modulePackage.main;
+            if (modulePackage.main) {
+                config._main = modulePackage.main;
+            }
             
             // prepare instance components
             if (config.client && (config.client.styles || config.client.markup)) {

--- a/lib/composition.js
+++ b/lib/composition.js
@@ -44,11 +44,6 @@ module.exports = function (name, related, role, callback) {
         // ensure name
         config.name = config.name || name;
 
-        // set cache alias for entrypoints
-        if (config.name !== name) {
-            config._cache_alias = engine.paths.app_composition + config.name + '.json';
-        }
-
         // merge related items to update cache on item change
         if (related) {
             config = File.relate(related, config);
@@ -73,6 +68,12 @@ module.exports = function (name, related, role, callback) {
         related = related || {};
         related.compositions = related.compositions || {};
         related.compositions[path] = true;
+        
+        // set cache alias for entrypoints
+        if (config.name !== name) {
+            config._cache_alias = engine.paths.app_composition + config.name + '.json';
+            related.compositions[config._cache_alias] = true;
+        }
         
         Module(config.module, related, function (err, modulePackage) {
             

--- a/lib/composition.js
+++ b/lib/composition.js
@@ -55,12 +55,6 @@ module.exports = function (name, related, role, callback) {
             related.compositions[config._cache_alias] = true;
         }
         
-        // merge related items to update cache on item change
-        config = File.relate(related, config);
-        
-        // add composition to related items
-        related.compositions[path] = true;
-        
         // create mandatory package infos to custom module
         if (typeof config.module === 'object') {
             config.module = {composition: config.module};
@@ -79,6 +73,12 @@ module.exports = function (name, related, role, callback) {
             related.modules = related.modules || {};
             related.modules[config.module._id] = true;
         }
+        
+        // merge related items to update cache on item change
+        config = File.relate(related, config);
+        
+        // add composition to related items
+        related.compositions[path] = true;
         
         Module(config.module, related, function (err, modulePackage) {
             

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -53,6 +53,10 @@ engine.load = function (name, role, callback) {
     // ensure callback
     callback = callback || function () {};
     
+    if (!name) {
+        return callback(new Error('No composition name.'));
+    }
+    
     // check instance chache
     if (engine.instances[name]) {
         
@@ -72,6 +76,10 @@ engine.load = function (name, role, callback) {
         
         if (err) {
             return callback(err);
+        }
+        
+        if (!composition._main) {
+            return callback(new Error('Module "' + composition.module + '" has no "main" config in the package.json.'));
         }
         
         // require module and create instance

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -49,7 +49,7 @@ engine.handlers = { transform: require('./client/transform') };
  * Create server module instances
  */
 engine.load = function (name, role, callback) {
-    
+
     // ensure callback
     callback = callback || function () {};
     
@@ -66,16 +66,16 @@ engine.load = function (name, role, callback) {
     // tell cache to remove instance on composition change
     var related = {instances: {}};
     related.instances[name] = true;
-    
+
     // get composition
     Composition(name, related, role, function (err, composition) {
         
         if (err) {
             return callback(err);
         }
-
+        
         // require module and create instance
-        Instance(require(engine.repo + 'node_modules/' + composition.module ), composition, role, callback);
+        Instance(require(composition._main), composition, role, callback);
     });
 };
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -27,9 +27,6 @@ var isWorker = /^\(W|S\)/;
 var checkFp = /\.@[a-z0-9]{7}\.(?:js|css|html)$/i;
 var replaceDoubleSlash = /\/{2,}/g;
 
-// this is not quaranteed to be stable!
-zlib.Z_DEFAULT_COMPRESSION = 9;
-
 // TODO stream data files into and from cache
 
 /**
@@ -381,7 +378,7 @@ function createFileDescriptor (file, data, callback, context) {
         return createCacheObject(file, callback, context);
     }
 
-    zlib.gzip(file.data, function (err, data) {
+    zlib.gzip(file.data, {level: zlib.Z_DEFAULT_COMPRESSION}, function (err, data) {
 
         if (err) {
             return callback(err, undefined, context);

--- a/lib/file.js
+++ b/lib/file.js
@@ -23,6 +23,7 @@ var html_minifier_options = {
 
 // regular expressions
 var suffix = /\.\w+$/;
+var isWorker = /^\(W|S\)/;
 var checkFp = /\.@[a-z0-9]{7}\.(?:js|css|html)$/i;
 var replaceDoubleSlash = /\/{2,}/g;
 
@@ -145,16 +146,24 @@ exports.prepare = function (components, callback) {
                 process.nextTick(handler, null, {ext: files[type][i]}, context);
                 continue;
             }
-          
+            
+            // get worker info
+            worker = false;
+            if (isWorker.test(files[type][i])) {
+                worker = files[type][i].substr(1,1);
+                files[type][i] = files[type][i].substr(3);
+            }
+
             this.get({
                 path: files[type][i],
                 // set public app folder for public files and the markup folder for markup files
                 base: files[type][i][0] === '/' ? (type === 'markup' ? engine.paths.app_markup : engine.paths.app_public) : base,
-                wrap: files[type][i] === 'resource.js' ? false : true,
+                wrap: files[type][i] === 'resource.js' || worker ? false : true,
                 module: components.module,
                 maxAge: engine.http.maxAge_fingerprint,
                 noCompression: engine.production && type === 'scripts' ? true : false,
-                related: components.related
+                related: components.related,
+                worker: worker
             }, handler, context);
         }
     }
@@ -362,7 +371,7 @@ function createFileDescriptor (file, data, callback, context) {
     }
     
     // prepend module id to path
-    file.ext = (file.module || '') + file.ext;
+    file.ext = (file.worker ? '(' + file.worker + ')' : '') + (file.module || '') + file.ext;
 
     // add the data to the file object
     file.data = data;

--- a/lib/file.js
+++ b/lib/file.js
@@ -289,9 +289,12 @@ function handleFileChange (err, event, path, type, key) {
         return;
     }
     
+    console.log('File "' + key + '" changed. Remove related items:');
+    
     // remove item itself
     cache.rm(key);
-    console.log('Removed from cache "' + type +'" item "' + key +'"');
+    
+    console.log('- ' + type + ':' + key);
     
     // remove related items
     if (item.related) {
@@ -306,7 +309,7 @@ function handleFileChange (err, event, path, type, key) {
             // remove items
             for (key in item.related[type]) {
                 cache.rm ? cache.rm(key) : delete engine.instances[key];
-                console.log('Removed from cache "' + type +'" item "' + key +'"');
+                console.log('- ' + type + ':' + key);
             }
         }
     }

--- a/lib/module.js
+++ b/lib/module.js
@@ -79,7 +79,9 @@ module.exports = function getModulePackage (module, related, callback, version, 
 function handleModule (modulePackage, related, callback, top) {
     
     // create absolute path to server main file
-    modulePackage.main = modulePackage._base + (modulePackage.main || modulePackage.module);
+    if (modulePackage.main) {
+        modulePackage.main = modulePackage._base + modulePackage.main;
+    }
     
     // check if client config exists
     var client = modulePackage.composition;

--- a/lib/module.js
+++ b/lib/module.js
@@ -44,6 +44,16 @@ module.exports = function getModulePackage (module, related, callback, version, 
             return callback(err);
         }
         
+        // check if module package has a name
+        if (!modulePackage.name) {
+            return callback(new Error('No module name in the package.'));
+        }
+        
+        // check if module package has a version
+        if (!modulePackage.version) {
+            return callback(new Error('No module version in the package.'));
+        }
+        
         // merge related items to update cache on item change
         if (related) {
           

--- a/lib/module.js
+++ b/lib/module.js
@@ -57,18 +57,6 @@ module.exports = function getModulePackage (module, related, callback, version, 
         // ensure module id
         modulePackage._id = modulePackage._id || modulePackage.name + '@' + modulePackage.version;
         
-        // merge related items to update cache on item change
-        if (related) {
-          
-            // append versioned module to top module related items
-            if (!version) {
-                related.modules = related.modules || {};
-                related.modules[modulePackage._id] = true;
-            }
-            
-            modulePackage = File.relate(related, modulePackage);
-        }
-        
         // save module base path
         modulePackage._base = base;
         
@@ -87,6 +75,20 @@ module.exports = function getModulePackage (module, related, callback, version, 
  * @param {object} The package of the parent module.
  */
 function handleModule (modulePackage, related, callback, top) {
+    
+    // add composition to related items
+    related = related || {};
+    related.modules = related.modules || {};
+    
+    if (top && modulePackage.version !== 'custom') {
+        related.modules[modulePackage.name] = true;
+    }
+    
+    // merge related items to update cache on item change
+    modulePackage = File.relate(related, modulePackage);
+    
+    // add module to related items
+    related.modules[modulePackage._id] = true;
     
     // create absolute path to server main file
     if (modulePackage.main) {
@@ -111,14 +113,6 @@ function handleModule (modulePackage, related, callback, top) {
     client = client.client;
     
     var callback_count = 0;
-    
-    // add composition to related items
-    related = related || {};
-    related.modules = related.modules || {};
-    related.modules[modulePackage._id] = true;
-    if (top) {
-        related.modules[modulePackage.name] = true;
-    }
     
     // handle client dependencies   
     if (client.dependencies) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -54,6 +54,9 @@ module.exports = function getModulePackage (module, related, callback, version, 
             return callback(new Error('No module version in the package.'));
         }
         
+        // ensure module id
+        modulePackage._id = modulePackage._id || modulePackage.name + '@' + modulePackage.version;
+        
         // merge related items to update cache on item change
         if (related) {
           
@@ -65,9 +68,6 @@ module.exports = function getModulePackage (module, related, callback, version, 
             
             modulePackage = File.relate(related, modulePackage);
         }
-        
-        // ensure module id
-        modulePackage._id = modulePackage._id || modulePackage.name + '@' + modulePackage.version;
         
         // save module base path
         modulePackage._base = base;

--- a/lib/module.js
+++ b/lib/module.js
@@ -78,6 +78,9 @@ module.exports = function getModulePackage (module, related, callback, version, 
  */
 function handleModule (modulePackage, related, callback, top) {
     
+    // create absolute path to server main file
+    modulePackage.main = modulePackage._base + (modulePackage.main || modulePackage.module);
+    
     // check if client config exists
     var client = modulePackage.composition;
     if (

--- a/lib/request.js
+++ b/lib/request.js
@@ -69,17 +69,19 @@ module.exports = function handler (req, res) {
             // get cached instance and check access
             } else {
     
-                // remove operation key, module instance name and event from path
-                path = path.slice(3);
-                
                 // get the event name
                 eventName = path[2];
                 
+                var instanceName = path[1];
+                
+                // remove operation key, module instance name and event from path
+                path = path.slice(3);
+                
                 // get instance
-                if (!(instance = engine.instances[path[1]])) {
+                if (!(instance = engine.instances[instanceName])) {
                     
                     // load an instance and setup stream
-                    return engine.load(path[1], session[engine.session_role], function (err, instance) {
+                    return engine.load(instanceName, (req.session || {})[engine.session_role], function (err, instance) {
                         
                         if (err) {
                             res.writeHead(404, defaultHeader);
@@ -100,20 +102,19 @@ module.exports = function handler (req, res) {
             instance = engine;
     }
     
+    setupStream(instance, eventName, req, res, path, url);
+};
+
+function setupStream (instance, eventName, req, res, path, url) {
     
     // check event access
-    if (!utils.eventAccess(instance, session[engine.session_role], eventName)) {
+    if (!utils.eventAccess(instance, (req.session || {})[engine.session_role], eventName)) {
 
         // send a "not found" if instance is not found or access denied
         res.writeHead(404, defaultHeader);
         res.end('Operation not found.');
         return;
     }
-    
-    setupStream(instance, eventName, req, res, path, url);
-};
-
-function setupStream (instance, eventName, req, res, path, url) {
     
     // create an event stream
     var stream = instance.flow(eventName, {

--- a/lib/static.js
+++ b/lib/static.js
@@ -308,12 +308,13 @@ function createModuleFileDescriptor (request) {
     file.base = modulePackage._base;
     
     // check if requested file is in the module client resources
-    var i, l;
+    var i, l, path;
     
     // script
     if (modulePackage.composition.client.module) {
         for (i = 0, l = modulePackage.composition.client.module.length; i < l; ++i) {
-            if (modulePackage.composition.client.module[i] === file.ext) {
+            path = modulePackage.composition.client.module[i];
+            if ((path.indexOf('(') === 0 ? path.substr(3) : path) === file.ext) {
                 return file;
             }
         }


### PR DESCRIPTION
Load dependency scripts as shared or dedicated workers.
Example package:

``` json
{
    "composition": {
        "client": {
            "module": [
                "normal/script.js",
                "(W)dedicated/worker.js",
                "(S)shared/worker.js"
            ]
        }
    }
}
```

Fixes #224 
Fixes #223 
Fixes #227 
Fixes #232
Fixes #237
Fixes #233
