### PR TITLE
Fixed buffered data writing in resume method.

### DIFF
--- a/lib/client/stream.js
+++ b/lib/client/stream.js
@@ -133,7 +133,7 @@ var Stream = {
         // write bufferd data
         if (this._b.length) {
             for (var i = 0, l = this._b.length; i < l; ++i) {
-                this.write(this._b[0], this._b[1]);
+                this.write(this._b[i][0], this._b[i][1]);
             }
         }
 


### PR DESCRIPTION
If I'm not missing anything, instead of `_b[0]` should be `_b[i][0]` (same for `[1]`).
