### PR TITLE
Application logs

### DIFF
--- a/lib/client/engine.js
+++ b/lib/client/engine.js
@@ -35,14 +35,14 @@ engine.load = function (name, role, callback, loaderInstance) {
     engine.flow('C').data(function (err, composition) {
 
         if (err) {
-            return callback(err);
+            return callback(engine.log('E', err));
         }
 
         // require module
         require(composition.module, function (module) {
 
-            if (err) {
-                return callback(err);
+            if (!module) {
+                return callback(engine.log('E', new Error('Module "' + composition.module + '" not found.')));
             }
 
             // create instance

--- a/lib/client/engine.js
+++ b/lib/client/engine.js
@@ -7,9 +7,11 @@ engine.client = true;
 // extend engine with flow emitter
 engine = Flow(engine);
 
+// extend engine with logging methods
+engine.log = require('./logs') || function () {};
+
 // listen to core engine events
 engine.mind('C', {call: '@/C'}).mind('M', {call: '@/M'});
-
 
 // data handlers
 engine.handlers = {

--- a/lib/client/flow.js
+++ b/lib/client/flow.js
@@ -148,7 +148,7 @@ function Flow (instance, originStream, config, context) {
 
         // check access
         if (session && !utils.roleAccess(instance, role)) {
-            return originStream.write(new Error('Flow target instance "' + config.to + '" is not found.'));
+            return originStream.write(engine.log('E', new Error('Flow target instance "' + config.to + '" is not found.')));
         }
     }
 
@@ -209,7 +209,7 @@ function getMethodFromPath (path, module_instance) {
         typeof path === 'string' &&
         typeof (path = utils.path(path, [engine.handlers, module_instance, global])) !== 'function'
     ) {
-        console.error('Flow method "' + _path + '" is not a function. Instance:' + module_instance._name);
+        engine.log('E', new Error('Flow method "' + _path + '" is not a function. Instance:' + module_instance._name));
         return;
     }
 

--- a/lib/client/instance.js
+++ b/lib/client/instance.js
@@ -28,8 +28,6 @@ module.exports = function factory (module, config, role, callback, loaderInstanc
     var countDown = 1;
     var readyHandler = function (err) {
 
-        // TODO handle error
-
         if (--countDown === 0) {
 
             // don't init dependency instances
@@ -159,6 +157,9 @@ function loadSnippets (urls, callback) {
 
         // ignore errors
         if (err || !html) {
+            
+            engine.log('E', err || new Error('Empty markup snippted.'));
+          
             // check if all snippets are loaded
             if (--count === 0) {
                 stream.end();

--- a/lib/client/instance.js
+++ b/lib/client/instance.js
@@ -1,9 +1,9 @@
 var Flow = require('./flow');
 var utils = require('./utils');
-var logs = engine.production ? function () {} : require('./logs');
 var isPublicPath = /^\/[^/]/;
 var styles = {};
 var markups = engine.markup = {};
+var dummyFn = function () {};
 
 // global module instance cache
 var instances = engine.instances = {};
@@ -67,7 +67,7 @@ module.exports = function factory (module, config, role, callback, loaderInstanc
     }
     
     // extend engine with logging methods
-    instance.log = logs || function () {};
+    instance.log = (engine.production ? dummyFn : require('./logs')) || dummyFn;
 
     // save module instance in cache
     instances[config.name] = instance;

--- a/lib/client/instance.js
+++ b/lib/client/instance.js
@@ -1,5 +1,6 @@
 var Flow = require('./flow');
 var utils = require('./utils');
+var logs = engine.production ? function () {} : require('./logs');
 var isPublicPath = /^\/[^/]/;
 var styles = {};
 var markups = engine.markup = {};
@@ -47,10 +48,8 @@ module.exports = function factory (module, config, role, callback, loaderInstanc
         }
     }
 
-    // save module instance in cache
-    instances[config.name] = instance;
-
     // extend instance
+    instance._module = config.module;
     instance._config = config.config || {};
     instance._name = config.name;
     instance._roles = config.roles || {};
@@ -66,6 +65,12 @@ module.exports = function factory (module, config, role, callback, loaderInstanc
         loaderInstance._load.push(config.name);
         loaderInstance._load.concat(config.load || []);
     }
+    
+    // extend engine with logging methods
+    instance.log = logs || function () {};
+
+    // save module instance in cache
+    instances[config.name] = instance;
 
     // load styles
     config.styles && loadStyles(config.styles);

--- a/lib/client/logs.js
+++ b/lib/client/logs.js
@@ -1,0 +1,93 @@
+var bunyan = require('bunyan');
+var logger;
+if (bunyan) {
+    logger = bunyan.createLogger({
+        name: engine.client ? engine.repo.split('/').slice(-2, -1) : 'client',
+        streams: [
+            {
+              level: 'info',
+              stream: process.stdout
+            },
+            {
+              level: 'debug',
+              stream: process.stdout
+            },
+            {
+              level: 'error',
+              stream: process.stdout
+            }
+        ],
+        serializers: bunyan.stdSerializers
+    });
+}
+
+// TODO
+module.exports = function (level, data, message, callback) {
+    
+    if (arguments.length < 2) {
+        return;
+    }
+    
+    // esure callback
+    callback = [].slice.apply(arguments).pop();
+    if (typeof callback !== 'function') {
+        callback = function () {};
+    }
+    
+    if (typeof data === 'string') {
+        message = data;
+        data = {};
+    }
+    
+    if (typeof message !== 'string') {
+        message = data.message || data.msg || '';
+    }
+    
+    // client console logs
+    if (engine.client) {
+        
+        if (message) {
+            data.level = level;
+            data.msg = message;
+        }
+        
+        console.log(data);
+        
+        return callback();
+    }
+    
+    if (bunyan && !this._log) {
+        this._log = logger.child({
+            module: this._module || 'engine',
+            instance: this._name || 'engine'
+        });
+    } 
+    
+    var log = this._log;
+    
+    // server logs
+    switch (level) {
+      case 'F':
+        log.fatal(data, message);
+        break;
+      case 'E':
+        log.error(data, message);
+        break;
+      case 'W':
+        log.warn(data, message);
+        break;
+      case 'I':
+        log.info(data, message);
+        break;
+      case 'D':
+        log.debug(data, message);
+        break;
+      case 'T':
+        log.trace(data, message);
+        break;
+      default:
+        log.error('Log level "' + level + '" is not a valid level.');
+    }
+    
+    callback();
+};

--- a/lib/client/logs.js
+++ b/lib/client/logs.js
@@ -39,55 +39,60 @@ module.exports = function (level, data, message, callback) {
         data = {};
     }
     
-    if (typeof message !== 'string') {
+    if (typeof message !== 'string' && typeof message !== 'number') {
         message = data.message || data.msg || '';
+    }
+    
+    // server logs
+    switch (level) {
+      case 'F':
+        level = 'fatal';
+        break;
+      case 'E':
+        level = 'error';
+        break;
+      case 'W':
+        level = 'warn';
+        break;
+      case 'I':
+        level = 'info';
+        break;
+      case 'D':
+        level = 'debug';
+        break;
+      case 'T':
+        level = 'trace';
+        break;
     }
     
     // client console logs
     if (engine.client) {
         
         if (message) {
-            data.level = level;
             data.msg = message;
         }
+        
+        data.level = level;
         
         console.log(data);
         
         return callback();
     }
     
-    if (bunyan && !this._log) {
+    // create a child logger for every instance
+    if (logger && !this._log) {
         this._log = logger.child({
             module: this._module || 'engine',
             instance: this._name || 'engine'
         });
     } 
     
-    var log = this._log;
-    
-    // server logs
-    switch (level) {
-      case 'F':
-        log.fatal(data, message);
-        break;
-      case 'E':
-        log.error(data, message);
-        break;
-      case 'W':
-        log.warn(data, message);
-        break;
-      case 'I':
-        log.info(data, message);
-        break;
-      case 'D':
-        log.debug(data, message);
-        break;
-      case 'T':
-        log.trace(data, message);
-        break;
-      default:
-        log.error('Log level "' + level + '" is not a valid level.');
+    if (!this._log[level]) {
+        return callback();
     }
+    
+    this._log[level](data, message);
+    
     
     callback();
 };

--- a/lib/client/logs.js
+++ b/lib/client/logs.js
@@ -2,35 +2,7 @@ var bunyan = require('bunyan');
 var logger;
 if (bunyan) {
     logger = bunyan.createLogger({
-        name: engine.repo ?  engine.repo.split('/').slice(-2, -1) : 'client',
-        
-        // TODO make log streams configurable with CLI arguments
-        streams: [
-            {
-              level: 'fatal',
-              stream: process.stderr
-            },
-            {
-              level: 'error',
-              stream: process.stderr
-            },
-            {
-              level: 'warn',
-              stream: process.stderr
-            },
-            {
-              level: 'info',
-              stream: process.stdout
-            },
-            {
-              level: 'debug',
-              stream: process.stdout
-            },
-            {
-              level: 'trace',
-              stream: process.stdout
-            }
-        ],
+        name: engine.repo ? engine.repo.split('/').slice(-2, -1)[0] : 'client',
         serializers: bunyan.stdSerializers
     });
 }
@@ -95,7 +67,7 @@ module.exports = function (level, data, message) {
     } 
     
     if (!this._log[level]) {
-        return callback();
+        return this._log.error(new Error('Invalid log level '+ level));
     }
     
     this._log[level](data, message);

--- a/lib/client/logs.js
+++ b/lib/client/logs.js
@@ -3,7 +3,21 @@ var logger;
 if (bunyan) {
     logger = bunyan.createLogger({
         name: engine.repo ?  engine.repo.split('/').slice(-2, -1) : 'client',
+        
+        // TODO make log streams configurable with CLI arguments
         streams: [
+            {
+              level: 'fatal',
+              stream: process.stderr
+            },
+            {
+              level: 'error',
+              stream: process.stderr
+            },
+            {
+              level: 'warn',
+              stream: process.stderr
+            },
             {
               level: 'info',
               stream: process.stdout
@@ -13,7 +27,7 @@ if (bunyan) {
               stream: process.stdout
             },
             {
-              level: 'error',
+              level: 'trace',
               stream: process.stdout
             }
         ],
@@ -21,7 +35,6 @@ if (bunyan) {
     });
 }
 
-// TODO
 module.exports = function (level, data, message, callback) {
     
     if (arguments.length < 2) {
@@ -92,7 +105,6 @@ module.exports = function (level, data, message, callback) {
     }
     
     this._log[level](data, message);
-    
     
     callback();
 };

--- a/lib/client/logs.js
+++ b/lib/client/logs.js
@@ -2,7 +2,7 @@ var bunyan = require('bunyan');
 var logger;
 if (bunyan) {
     logger = bunyan.createLogger({
-        name: engine.client ? engine.repo.split('/').slice(-2, -1) : 'client',
+        name: engine.repo ?  engine.repo.split('/').slice(-2, -1) : 'client',
         streams: [
             {
               level: 'info',

--- a/lib/client/logs.js
+++ b/lib/client/logs.js
@@ -35,16 +35,10 @@ if (bunyan) {
     });
 }
 
-module.exports = function (level, data, message, callback) {
+module.exports = function (level, data, message) {
     
     if (arguments.length < 2) {
         return;
-    }
-    
-    // esure callback
-    callback = [].slice.apply(arguments).pop();
-    if (typeof callback !== 'function') {
-        callback = function () {};
     }
     
     if (typeof data === 'string') {
@@ -89,7 +83,7 @@ module.exports = function (level, data, message, callback) {
         
         console.log(data);
         
-        return callback();
+        return data;
     }
     
     // create a child logger for every instance
@@ -106,5 +100,5 @@ module.exports = function (level, data, message, callback) {
     
     this._log[level](data, message);
     
-    callback();
+    return data;
 };

--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -16,7 +16,7 @@ function setupStream (stream, url) {
 
     // append parsed url on stream
     if (typeof url === 'string' && !(url = parseUrl(url))) {
-        return console.error('Invalid socket url.');
+        return engine.log('E', new Error('Invalid socket URL.'));
     }
 
     // create stream id
@@ -144,7 +144,7 @@ function send (err, data, stream, end) {
     try {
         message = JSON.stringify(message);
     } catch (err) {
-        return console.error(err);
+        return engine.log('E', err);
     }
 
     // buffer writes if socket is not ready yet
@@ -202,7 +202,7 @@ function parseMessage (messageEvent) {
     try {
         message = JSON.parse(message);
     } catch (error) {
-        return console.error(error);
+        return engine.log('E', error);
     }
 
     // extract data from parsed message
@@ -235,10 +235,11 @@ function parseMessage (messageEvent) {
             if (!(instance = engine.instances[instance])) {
 
                 // load an instance
-                // TODO buffer messages for this instance (pause)
+                stream.pause();
                 engine.load(message[1], role, function (err, instance) {
 
                     if (err) {
+                        
                         // send error back
                         message[4] = err;
                         message[5] = 0;
@@ -247,6 +248,8 @@ function parseMessage (messageEvent) {
 
                     // create a new stream and save it in cache and write data
                     createStream(instance, event, id, socket, message[1]).write(err, data);
+                    
+                    stream.resume();
                 });
                 return;
 

--- a/lib/client/utils.js
+++ b/lib/client/utils.js
@@ -142,15 +142,6 @@ exports.deep = function (object) {
     return result;
 };
 
-/**
- * Convert array like object into real Arrays.
- *
- * @public
- * @param {object} The object, which is converted to an array.
- */
-exports.toArray = function (object) {
-    return Array.prototype.slice.call(object);
-};
 
 /**
  * Retruns a random string.

--- a/lib/composition.js
+++ b/lib/composition.js
@@ -38,7 +38,7 @@ module.exports = function (name, related, role, callback) {
 
         // handle error
         if ((err = err || checkComposition(name, path, role, config))) {
-            return callback(engine.log('E', err));
+            return callback(err);
         }
 
         // ensure name
@@ -84,7 +84,7 @@ module.exports = function (name, related, role, callback) {
 
             // handle module package error
             if (err) {
-                return callback(engine.log('E', err));
+                return callback(err);
             }
 
             // set packages server main in composition, to require server side module
@@ -107,7 +107,7 @@ module.exports = function (name, related, role, callback) {
                 File.prepare(components, function (err, files) {
                     
                     if (err) {
-                        return callback(engine.log('E', err));
+                        return callback(err);
                     }
                     
                     // update file paths in module package
@@ -150,7 +150,7 @@ function checkComposition (name, path, role, config) {
 
     // handle not found
     if (!config) {
-        return new Error('composition "' + name +'" not found.');
+        return engine.log('E', new Error('composition "' + name +'" not found.'));
     }
 
     // check if composition has a module
@@ -158,7 +158,7 @@ function checkComposition (name, path, role, config) {
 
         // save as invalid in cache
         composition_cache.set(path, 'INVALID');
-        return new Error('No module info in composition "' + name + '".');
+        return engine.log('E', new Error('No module info in composition "' + name + '".'));
     }
 
     // check access
@@ -166,7 +166,7 @@ function checkComposition (name, path, role, config) {
 
         // save access information in cache, to check access without loading the hole file again
         composition_cache.set(path, {roles: config.roles, LOAD: true});
-        return new Error('Access denied: Role "' + role + '", Composition "' + name + '".');
+        return engine.log('E', new Error('Access denied: Role "' + role + '", Composition "' + name + '".'));
     }
 
     // set composition name as custom module name

--- a/lib/composition.js
+++ b/lib/composition.js
@@ -16,12 +16,12 @@ module.exports = function (name, related, role, callback) {
     if (composition) {
 
         if (composition === 'INVALID') {
-            return callback(new Error('Invalid composition "' + name + '".'));
+            return callback(engine.log('E', new Error('Invalid composition "' + name + '".')));
         }
 
         // check access for cached item
         if (!utils.roleAccess(composition, role)) {
-            return callback(new Error('Access denied for composition "' + name + '"'));
+            return callback(engine.log('E', new Error('Access denied for composition "' + name + '"')));
         }
 
         // add related instances to composition and update cache
@@ -38,7 +38,7 @@ module.exports = function (name, related, role, callback) {
 
         // handle error
         if ((err = err || checkComposition(name, path, role, config))) {
-            return callback(err);
+            return callback(engine.log('E', err));
         }
 
         // ensure name
@@ -84,7 +84,7 @@ module.exports = function (name, related, role, callback) {
 
             // handle module package error
             if (err) {
-                return callback(err);
+                return callback(engine.log('E', err));
             }
 
             // set packages server main in composition, to require server side module
@@ -105,7 +105,11 @@ module.exports = function (name, related, role, callback) {
                 };
 
                 File.prepare(components, function (err, files) {
-
+                    
+                    if (err) {
+                        return callback(engine.log('E', err));
+                    }
+                    
                     // update file paths in module package
                     if (files.styles) {
                         config.client.styles = files.styles;

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -43,7 +43,10 @@ var Instance = require('./client/instance');
 var Static = require('./static');
 var utils = require('./client/utils');
 
-engine.handlers = { transform: require('./client/transform') };
+// data transform handlers
+engine.handlers = {
+    transform: require('./client/transform')
+};
 
 /**
  * Create server module instances
@@ -110,6 +113,9 @@ module.exports = function start (repo, port, production) {
         app_composition: engine.repo + 'composition/'
     };
     
+    // extend engine with logging methods
+    engine.log = engine.production ? function () {} : require('./client/logs');
+    
     // save engine in instances cache under the operation id
     engine.instances[engine.operation_id] = engine;
 
@@ -127,8 +133,8 @@ module.exports = function start (repo, port, production) {
               .mind('P', {call: Static.public})
               .mind('F', {call: Static.file})
               .mind('W', {call: Static.wrap})
-              // load html snippted over websocket,
-              // until html imports are supported
+              // TODO load html snippted over websocket,
+              //      until html imports are supported
               .mind('M', {call: Static.markup})
               .mind('C', {call: Static.composition});
         

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -57,14 +57,14 @@ engine.load = function (name, role, callback) {
     callback = callback || function () {};
 
     if (!name) {
-        return callback(new Error('No composition name.'));
+        return callback(engine.log('E', new Error('No composition name.')));
     }
 
     // check instance chache
     if (engine.instances[name]) {
 
         if (!utils.roleAccess(engine.instances[name], role)) {
-            return callback(new Error('Access denied for instance:' + name));
+            return callback(engine.log('E', new Error('Access denied for instance:' + name)));
         }
 
         return callback(null, engine.instances[name]);
@@ -82,7 +82,7 @@ engine.load = function (name, role, callback) {
         }
 
         if (!composition._main) {
-            return callback(new Error('Module "' + composition.module + '" has no "main" config in the package.json.'));
+            return callback(engine.log('E', new Error('Module "' + composition.module + '" has no "main" config in the package.json.')));
         }
 
         // require module and create instance

--- a/lib/file.js
+++ b/lib/file.js
@@ -289,13 +289,17 @@ function handleFileChange (err, event, path, type, key) {
     if (!item) {
         return;
     }
-
-    console.log('File "' + key + '" changed. Remove related items:');
+    
+    var log = {
+        file: key,
+        removed: [{
+            cache: type,
+            item: key
+        }]
+    };
 
     // remove item itself
     cache.rm(key);
-
-    console.log('- ' + type + ':' + key);
 
     // remove related items
     if (item.related) {
@@ -310,10 +314,15 @@ function handleFileChange (err, event, path, type, key) {
             // remove items
             for (key in item.related[type]) {
                 cache.rm ? cache.rm(key) : delete engine.instances[key];
-                console.log('- ' + type + ':' + key);
+                log.removed.push({
+                    cache: type,
+                    item: key
+                });
             }
         }
     }
+    
+    engine.log('D', log, 'File changed.');
 }
 
 /**

--- a/lib/file.js
+++ b/lib/file.js
@@ -78,6 +78,10 @@ exports.prepare = function (components, callback) {
 
     var handler = function (err, file, context) {
         if (err) {
+            
+            // log error
+            engine.log('E', err);
+            
             if (--countDown === 0) {
                 callback(null, components);
             }
@@ -109,7 +113,7 @@ exports.prepare = function (components, callback) {
                 createFileDescriptor(combinedFile, combinedFile.data, function (err, file) {
 
                     if (err) {
-                        return callback(err);
+                        return callback(engine.log('E', err));
                     }
 
                     // overwrite module resources
@@ -175,11 +179,11 @@ exports.json = function (path, callback, type, key) {
     fs.readJson(path, function (err, object) {
 
         if (err) {
-            return callback(err);
+            return callback(engine.log('E', err));
         }
 
         if (!object) {
-            return callback(new Error('JSON file "' + path + '" not found.'));
+            return callback(engine.log('E', new Error('JSON file "' + path + '" not found.')));
         }
 
         // watch file changes
@@ -231,14 +235,14 @@ exports.get = function (file, callback, context) {
     fs.readFile(file.read, function (err, data) {
 
         if (err) {
-            return callback(err, undefined, context);
+            return callback(engine.log('E', err), undefined, context);
         }
 
         // get the modification time
         fs.stat(file.read, function (err, stats) {
 
             if (err) {
-                return callback(err, undefined, context);
+                return callback(engine.log('E', err), undefined, context);
             }
 
             // watch file changes
@@ -276,7 +280,7 @@ exports.relate = function (related, object) {
 function handleFileChange (err, event, path, type, key) {
 
     if (err) {
-        return;
+        return engine.log('E', err);
     }
 
     key = key || path;
@@ -394,7 +398,7 @@ function createFileDescriptor (file, data, callback, context) {
     zlib.gzip(file.data, {level: zlib.Z_DEFAULT_COMPRESSION}, function (err, data) {
 
         if (err) {
-            return callback(err, undefined, context);
+            return callback(engine.log('E', err), undefined, context);
         }
 
         // update file data with compressed data

--- a/lib/file.js
+++ b/lib/file.js
@@ -77,6 +77,7 @@ exports.prepare = function (components, callback) {
     };
 
     var handler = function (err, file, context) {
+
         if (err) {
             
             // log error

--- a/lib/file.js
+++ b/lib/file.js
@@ -327,7 +327,7 @@ function handleFileChange (err, event, path, type, key) {
         }
     }
     
-    engine.log('D', log, 'File changed.');
+    engine.log('I', log, 'File changed.');
 }
 
 /**

--- a/lib/module.js
+++ b/lib/module.js
@@ -42,7 +42,7 @@ module.exports = function getModulePackage (module, related, callback, version, 
 
         // handle error
         if (err) {
-            return callback(engine.log('E', err));
+            return callback(err);
         }
 
         // check if module package has a name
@@ -125,9 +125,6 @@ function handleModule (modulePackage, related, callback, top) {
 
             // handle error
             if (err) {
-                
-                engine.log('E', err);
-                
                 if (--countDown === 0 && --callback_count === 0) {
                     callback(err);
                 }
@@ -163,7 +160,7 @@ function handleModule (modulePackage, related, callback, top) {
 
             // check if client dependency exists
             if (!modulePackage.dependencies[client.dependencies[i]]) {
-                return utils.nextTick(recursiveHandler, new Error('Client module dependency not found.'));
+                return utils.nextTick(recursiveHandler, engine.log('E', new Error('Client module dependency not found.')));
             }
 
             // merge client packages
@@ -194,7 +191,7 @@ function handleModule (modulePackage, related, callback, top) {
         File.prepare(components, function (err, files) {
 
             if (err) {
-                return callback(engine.log('E', err));
+                return callback(err);
             }
 
             // update file paths in module package

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,11 +1,11 @@
 var File = require('./file');
 var Cache = require('./cache');
 var module_cache = Cache('modules');
-var utils = require("./client/utils")
+var utils = require("./client/utils");
 
 /**
  * Parse and get the engine package infos.
- *
+ *er
  * @private
  * @param {string} The module name or the custom module config object.
  * @param {function} The callback function.
@@ -42,17 +42,17 @@ module.exports = function getModulePackage (module, related, callback, version, 
 
         // handle error
         if (err) {
-            return callback(err);
+            return callback(engine.log('E', err));
         }
 
         // check if module package has a name
         if (!modulePackage.name) {
-            return callback(new Error('No module name in the package.'));
+            return callback(engine.log('E', new Error('No module name in the package.')));
         }
 
         // check if module package has a version
         if (!modulePackage.version) {
-            return callback(new Error('No module version in the package.'));
+            return callback(engine.log('E', new Error('No module version in the package.')));
         }
 
         // ensure module id
@@ -125,6 +125,9 @@ function handleModule (modulePackage, related, callback, top) {
 
             // handle error
             if (err) {
+                
+                engine.log('E', err);
+                
                 if (--countDown === 0 && --callback_count === 0) {
                     callback(err);
                 }
@@ -191,7 +194,7 @@ function handleModule (modulePackage, related, callback, top) {
         File.prepare(components, function (err, files) {
 
             if (err) {
-                return callback(err);
+                return callback(engine.log('E', err));
             }
 
             // update file paths in module package

--- a/lib/request.js
+++ b/lib/request.js
@@ -84,7 +84,6 @@ module.exports = function handler (req, res) {
                     return engine.load(instanceName, (req.session || {})[engine.session_role], function (err, instance) {
 
                         if (err) {
-                            engine.log('E', err);
                             res.writeHead(404, defaultHeader);
                             res.end(err.toString());
                             return;
@@ -153,7 +152,6 @@ function send (err, data, stream) {
     if (data === false) {
         code = 500;
         data = 'JSON stringify error';
-        engine.log('E', {code: code}, data);
         return stream.end(code, data);
     }
 
@@ -176,7 +174,6 @@ function end (code, data) {
     if (data === false) {
         code = 500;
         data = 'JSON stringify error';
-        engine.log('E', {code: code}, data);
     }
 
     this.headers['Content-Length'] = data.length;

--- a/lib/request.js
+++ b/lib/request.js
@@ -84,6 +84,7 @@ module.exports = function handler (req, res) {
                     return engine.load(instanceName, (req.session || {})[engine.session_role], function (err, instance) {
 
                         if (err) {
+                            engine.log('E', err);
                             res.writeHead(404, defaultHeader);
                             res.end(err.toString());
                             return;
@@ -136,6 +137,7 @@ function setupStream (instance, eventName, req, res, path, url) {
 
     // write error to event streams
     req.on('error', function (error) {
+        engine.log('E', error);
         stream.write(error);
     });
 
@@ -151,6 +153,7 @@ function send (err, data, stream) {
     if (data === false) {
         code = 500;
         data = 'JSON stringify error';
+        engine.log('E', {code: code}, data);
         return stream.end(code, data);
     }
 
@@ -173,6 +176,7 @@ function end (code, data) {
     if (data === false) {
         code = 500;
         data = 'JSON stringify error';
+        engine.log('E', {code: code}, data);
     }
 
     this.headers['Content-Length'] = data.length;
@@ -209,6 +213,9 @@ function convertToBuffer (data, headers) {
             headers['content-type'] = 'application/json; charset=utf-8';
         }
     } catch (err) {
+        
+        engine.log('E', err);
+        
         if (headers) {
             headers['content-type'] = 'text/plain';
         }

--- a/lib/static.js
+++ b/lib/static.js
@@ -68,7 +68,6 @@ exports.client = function (stream) {
 
         // send the error in the browser
         if (err) {
-            engine.log('E', err);
             stream.headers = {'Content-Type': 'text/plain; charset=utf-8'};
             return stream.end(500, err.toString());
         }
@@ -127,7 +126,6 @@ exports.public = function (stream) {
     }, function (err, file) {
 
         if (err) {
-            engine.log('E', err);
             stream.headers = {'Content-Type': 'text/plain; charset=utf-8'};
             stream.end(404, 'File "' + stream.pathname + '" not found.');
             return;
@@ -181,7 +179,6 @@ exports.composition = function (stream) {
         Composition(instance, related, role, function (err, composition) {
 
             if (err) {
-                engine.log('E', err);
                 return stream.write(err.toString());
             }
 
@@ -219,7 +216,6 @@ exports.file = function (stream) {
     File.get(file, function (err, script) {
 
         if (err) {
-            engine.log('E', err);
             stream.headers = {'content-type': 'text/plain'};
             return stream.end(404, err.toString());
         }
@@ -266,7 +262,6 @@ exports.markup = function (stream) {
 
             if (err || !file && !file.data) {
                 err = err|| 'HTML snippet not found.';
-                engine.log('E', err);
                 return stream.write(err);
             }
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -58,6 +58,11 @@ exports.client = function (stream) {
             'resource.js'
         ]
     };
+    
+    // load logger module in dev mode
+    if (!engine.production) {
+        loadContext.scripts.splice(1, 0, 'logs.js');
+    }
 
     File.prepare(loadContext, function (err, files) {
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -68,6 +68,7 @@ exports.client = function (stream) {
 
         // send the error in the browser
         if (err) {
+            engine.log('E', err);
             stream.headers = {'Content-Type': 'text/plain; charset=utf-8'};
             return stream.end(500, err.toString());
         }
@@ -94,6 +95,7 @@ exports.client = function (stream) {
 
                 // send the error in the browser
                 if (err) {
+                    engine.log('E', err);
                     stream.headers = {'Content-Type': 'text/plain; charset=utf-8'};
                     return stream.end(500, err.toString());
                 }
@@ -125,6 +127,7 @@ exports.public = function (stream) {
     }, function (err, file) {
 
         if (err) {
+            engine.log('E', err);
             stream.headers = {'Content-Type': 'text/plain; charset=utf-8'};
             stream.end(404, 'File "' + stream.pathname + '" not found.');
             return;
@@ -178,6 +181,7 @@ exports.composition = function (stream) {
         Composition(instance, related, role, function (err, composition) {
 
             if (err) {
+                engine.log('E', err);
                 return stream.write(err.toString());
             }
 
@@ -215,6 +219,7 @@ exports.file = function (stream) {
     File.get(file, function (err, script) {
 
         if (err) {
+            engine.log('E', err);
             stream.headers = {'content-type': 'text/plain'};
             return stream.end(404, err.toString());
         }
@@ -234,10 +239,6 @@ exports.markup = function (stream) {
     var self = this;
 
     stream.data(function (err, path) {
-
-        if (err) {
-            return stream.write(err.toString());
-        }
 
         var file = {
             path: path,
@@ -265,6 +266,7 @@ exports.markup = function (stream) {
 
             if (err || !file && !file.data) {
                 err = err|| 'HTML snippet not found.';
+                engine.log('E', err);
                 return stream.write(err);
             }
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -61,7 +61,7 @@ exports.client = function (stream) {
     
     // load logger module in dev mode
     if (!engine.production) {
-        loadContext.scripts.splice(1, 0, 'logs.js');
+        loadContext.scripts.splice(-2, 0, 'logs.js');
     }
 
     File.prepare(loadContext, function (err, files) {

--- a/package.json
+++ b/package.json
@@ -22,15 +22,16 @@
     "framework"
   ],
   "dependencies": {
-    "ws": "0.7.1",
-    "mime": "1.2.11",
-    "cookie": "0.1.2",
-    "uglify-js": "2.4.16",
-    "html-minifier": "0.7.0 ",
-    "clean-css": "3.0.8",
-    "fs-extra": "0.16.3",
+    "ws": "0.7.2",
+    "mime": "1.3.4",
+    "cookie": "0.1.3",
+    "uglify-js": "2.4.23",
+    "html-minifier": "0.7.2",
+    "clean-css": "3.3.5",
+    "fs-extra": "0.22.0",
     "fwatcher": "2.0.0",
-    "wrabbit": "2.1.0"
+    "wrabbit": "2.1.0",
+    "bunyan": "1.4.0"
   },
   "engine": {
     "node": ">=0.10"


### PR DESCRIPTION
Implement a method on the `engine` and all `instances` to write all types of logs.
Example:

``` js
// engine (only for use in core engine modules)
engine.log('logLevel', {my: 'infos'}, 'message');
engine.log('logLevel', 'message');

// instances
this.log('logLevel', {my: 'infos'}, 'message');
this.log('logLevel', 'message');
```

There are predefined log levels:
- `F` or `fatal`
- `E` or `error`
- `W` or  `warn`
- `I` or  `info`
- `D` or  `debug`
- `T` or  `trace`

The log output on the server is handled with [trentm/node-bunyan](https://github.com/trentm/node-bunyan).

Fixes #91 
Fixes #243 
Fixes #241 
