### PR TITLE
Entrypoints map in package.json

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -110,6 +110,12 @@ module.exports = function start (repo, port, logLevel, production) {
     // extend engine with logging methods
     engine.log = require('./client/logs');
 
+    // get package
+    engine.package = require(engine.repo + 'package');
+    if (!engine.package || !engine.package.entrypoints) {
+        throw new Error('No entrypoints found in package.json');
+    }
+
     // save engine in instances cache under the operation id
     engine.instances[engine.operation_id] = engine;
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -11,7 +11,8 @@ var utils = require("./client/utils");
  * @param {function} The callback function.
  * @param {object} The package of the parent module.
  */
-module.exports = function getModulePackage (module, related, callback, version, base) {
+ module.exports = getModulePackage;
+ function getModulePackage (module, related, callback, version, base) {
 
     // get cache key to look for cached packages
     var moduleId = module._id || module + (version ? '@' + version : '');

--- a/lib/static.js
+++ b/lib/static.js
@@ -20,6 +20,15 @@ var resHeaders = {
 };
 var defaultHeaders = {'content-type': 'text/plain; charset=utf-8'};
 
+var entrypoints = [
+    {
+        '*': 'public_layout'
+    },
+    {
+        '*': 'private_layout'
+    }
+];
+
 /**
  * Send the index document to the client.
  *
@@ -186,7 +195,15 @@ exports.composition = function (stream) {
 
             // get the public version of the entrypoint module instance
             if (!role) {
-                instance += '.pub';
+                instance = entrypoints[0][instance] || entrypoints[0]['*'];
+            } else {
+                instance = entrypoints[1][instance] || entrypoints[1]['*'];
+            }
+
+            if (!instance) {
+                return stream.write(
+                    engine.log('E', 'Static: Composition entrypoint not found.')
+                );
             }
         }
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -184,12 +184,9 @@ exports.composition = function (stream) {
 
             instance = socket.upgradeReq.headers.host.split(':')[0];
 
-            // get the public version of the entrypoint module instance
-            if (!role) {
-                instance = engine.package.entrypoints[0][instance] || engine.package.entrypoints[0]['*'];
-            } else {
-                instance = engine.package.entrypoints[1][instance] || engine.package.entrypoints[1]['*'];
-            }
+            // get the entrypoint module instance
+            var entrypoints = engine.package.entrypoints[role ? 'private' : 'public'];
+            instance = entrypoints[instance] || entrypoints['*'];
 
             if (!instance) {
                 return stream.write(

--- a/lib/static.js
+++ b/lib/static.js
@@ -20,15 +20,6 @@ var resHeaders = {
 };
 var defaultHeaders = {'content-type': 'text/plain; charset=utf-8'};
 
-var entrypoints = [
-    {
-        '*': 'public_layout'
-    },
-    {
-        '*': 'private_layout'
-    }
-];
-
 /**
  * Send the index document to the client.
  *
@@ -195,9 +186,9 @@ exports.composition = function (stream) {
 
             // get the public version of the entrypoint module instance
             if (!role) {
-                instance = entrypoints[0][instance] || entrypoints[0]['*'];
+                instance = engine.package.entrypoints[0][instance] || engine.package.entrypoints[0]['*'];
             } else {
-                instance = entrypoints[1][instance] || entrypoints[1]['*'];
+                instance = engine.package.entrypoints[1][instance] || engine.package.entrypoints[1]['*'];
             }
 
             if (!instance) {


### PR DESCRIPTION
Map the domains to `entrypoint` instances in the `package.json` like this:

``` json
{
    "entrypoints": {
        "public": {
            "*": "any_domain_public",
            "mydomain.com": "mydomain_public"
        },
        "private": {
            "*": "any_domain_private",
            "mydomain.com": "mydomain_private"
        }
    }
}
```
