### PR TITLE
Bind the console.log method

### DIFF
--- a/lib/flow.client.js
+++ b/lib/flow.client.js
@@ -2,6 +2,8 @@ var Flow = require('flow');
 var http = require('./http');
 var ws = require('./websocket');
 
+var consoleLog = console.log.bind(console);
+
 // init flow with core module
 Flow({
 
@@ -30,7 +32,7 @@ Flow({
             composition._roles = {'*': true};
             callback(err, composition);
         })
-        fes.o.on('error', console.log.bind(console));
+        fes.o.on('error', consoleLog);
         fes.i.end(name);
     },
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "client-sessions": "^0.7.0",
     "closurecompiler": "^1.5.2",
     "express": "^4.13.3",
-    "flow": "github:jillix/flow",
+    "flow": "jillix/flow",
     "flowhttp": "^0.3.0",
     "spdy": "^3.0.0",
     "stream-browserify": "^2.0.1",


### PR DESCRIPTION
No need to bind it every time, but just once.
