### PR TITLE
The new CLI syntax allowing any position for port and log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 Flow-App
 ======
+
 A flow web server.
 
-###Install the server
+### Install the server
+
 * Append `flow-app` as a dependency in your app's `package.json`:
 ```json
 {
@@ -15,28 +17,42 @@ A flow web server.
 ```json
 "scripts": {
     "install": "flow-pack . -i flow-app.",
-    "start": "flow-app -c ssl/dev.crt -k ssl/dev.key .",
+    "start": "flow-app . -c path/to/ssl/certificate.pem -k path/to/ssl/key.pem",
     "debug": "flow-pack . -di flow-app; npm start"
 }
 ```
 
 ### Install the app
+
 1. Clone the repository: `git clone [git_url]`
 2. Change directory: `cd [app_repo_dir]/` and do a `npm install`
 
-###Start an app
+### Start an app
+
 Go into your app root folder and do:
+
 ```sh
-$ npm start [port] ["fatal|error|warn|info|debug|trace"]
+$ npm start
 ```
-###Reload an app
-Reload recomiles the module bundles. Meant to use while developing.
+
+To change the default port (`8000`) and log level (`error`) use:
+
 ```sh
-$ npm run reload [port] ["fatal|error|warn|info|debug|trace"]
+$ npm start -- [-p <port>] [-l <fatal|error|warn|info|debug|trace>]
+```
+
+### Reload an app
+
+Reload recompiles the module bundles. Meant for use while developing.
+
+```sh
+$ npm run-script reload -- [-p <port>] [-l <fatal|error|warn|info|debug|trace>]
 ```
 
 ### Module package extension
+
 Extend the `npm` `package.json` with a `composition` object, to define a default config for instances of the module:
+
 ```json
 {
     "composition": {
@@ -46,18 +62,23 @@ Extend the `npm` `package.json` with a `composition` object, to define a default
     }
 }
 ```
+
 ##### Composition with custom module:
+
 To create a custom module instance form a app repo file, just define a path as module name.
 The base path for custom module files is: `*/app/app_modules`. 
+
 ```json
 {
     "module": "/module/main.js",
     "browser": "/module/client.js",
 }
 ```
+
 The `browser` field represents the [browserify "browser" option](https://github.com/substack/node-browserify#browser-field).
 
-###Path types
+### Path types
+
 Request files from a configured `public` directory, fetch module bundle file and call operations on the server side.
 Note that, the first segment of a public file URL cannot contain a `:` char, since they are used to route to the to the corresponding operation.
 
@@ -67,19 +88,24 @@ Note that, the first segment of a public file URL cannot contain a `:` char, sin
 * `/module/*`
 * `/app_module/*`
 
-#####Public file path `/`
+##### Public file path `/`
+
 Example: `/path/to/public/file.suffix`
 
-#####Module file path `/module/[module]/bundle.[fingerprint].js/`
+##### Module file path `/module/[module]/bundle.[fingerprint].js/`
+
 * Production example: `/module/view/bundle.273dhs7.js`
 * Debug example: `/module/view/bundle.js`
 
-#####Custom module file path `/app_module/[module]/bundle.[fingerprint].js/`
+##### Custom module file path `/app_module/[module]/bundle.[fingerprint].js/`
+
 * Production example: `/app_module/view/bundle.273dhs7.js`
 * Debug example: `/app_module/view/bundle.js`
 
-#####Flow emit path `/flow/[module_instance]:[event]/`
+##### Flow emit path `/flow/[module_instance]:[event]/`
+
 Example: `/flow/registration:verifyEmail/tokenX/?locale=en_US#hash`
 
-#####Module instance composition path `/flow_comp/[module_instance]`
+##### Module instance composition path `/flow_comp/[module_instance]`
+
 Example: `/flow_comp/compositionName`

--- a/bin/config.js
+++ b/bin/config.js
@@ -1,30 +1,43 @@
+var DEFAULT_PORT = 8000;
+var DEFAULT_LOG_LEVEL = 'error';
+
 var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
+
 var argv = require('yargs')
     .option('t', {
         alias: 'token',
         type: 'string',
-        describe: 'Set secret tocken for client sessions.'
+        describe: 'Set secret token for client sessions'
     })
     .option('c', {
         alias: 'sslCert',
         type: 'string',
         demand: true,
         requiresArg: 'k',
-        describe: 'Path to the SSL certificate file.'
+        describe: 'Path to the SSL certificate file'
     })
     .option('k', {
         alias: 'sslKey',
         type: 'string',
         demand: true,
         requiresArg: 'c',
-        describe: 'Path to the SSL key file.'
+        describe: 'Path to the SSL key file'
+    })
+    .option('p', {
+        alias: 'port',
+        default: DEFAULT_PORT,
+        describe: 'Port to start the application on (default: ' + DEFAULT_PORT + ')'
+    })
+    .option('l', {
+        alias: 'log-level',
+        default: DEFAULT_LOG_LEVEL,
+        describe: 'The application log level: [fatal|error|warn|info|debug|trace] (default: ' + DEFAULT_LOG_LEVEL + ')'
     })
 
-    // check if repo path exists
+    // check if app path exists
     .check(function (argv) {
-
         argv._[0] = argv._[0] || '.';
         argv.repo = path.resolve(argv._[0]);
 
@@ -33,21 +46,15 @@ var argv = require('yargs')
         }
     })
 
-    // check if port is a number
+    // check for valid port number
     .check(function (argv) {
 
-        if (argv._[1]) {
-            argv.port = typeof argv._[1] === 'number' ? argv._[1] : parseInt(argv._[1].replace(/[^0-9]/, ''));
+        var port = Number(argv.p);
 
-            if (argv.port) {
-                return true;
-            }
-
-        // set default port
-        } else {
-            argv.port = 8000;
-            return true;
+        if (typeof(argv.p) === 'boolean' || isNaN(port) || port < 1 || port > 65535) {
+            return 'Invalid port number. Choose a number from 1 to 65535.';
         }
+        return true;
     })
 
     // check if ssl certificates exists
@@ -55,28 +62,30 @@ var argv = require('yargs')
 
         argv.ssl = {};
 
-        // check if ssl certificate exists
-        if (typeof argv.c === 'string') {
+        // file read will throw an error
+        try {
             argv.ssl.cert = fs.readFileSync(path.resolve(argv.c));
+        } catch (err) {
+            return 'Cannot read the certificate file\n' + err;
         }
-
-        // check if ssl key file exists
-        if (typeof argv.k === 'string') {
+        try {
             argv.ssl.key = fs.readFileSync(path.resolve(argv.k));
+        } catch (err) {
+            return 'Cannot read the certificate key file\n' + err;
         }
 
-        if (argv.ssl.cert && argv.ssl.key) {
-            return true;
-        }
+        return true;
     })
 
-    .usage('flow-app [options] [APP_REPO_PATH] [PORT]')
-    .example('flow-app /usr/src/app 8000', "Start flow app node.")
-    .example('flow-app -t secretToken /usr/src/app 8000', "Define a secret token for client sessions.")
-    .example('flow-app -c /path/to/cert.pem -k /path/to/key.pem 8000', "Define SSL certificate")
+    .usage('flow-app [options] <APP_REPO_PATH>')
+    .example('flow-app -c path/to/cert.pem -k path/to/key.pem path/to/app', 'Start an app')
+    .example('flow-app -c path/to/cert.pem -k path/to/key.pem -t "secretToken" path/to/app', 'Define a secret token for client sessions')
+    .example('flow-app -c path/to/cert.pem -k path/to/key.pem -p 1234 path/to/app', 'Start an app on port 1234')
     .help('h')
     .alias('h', 'help')
+    .showHelpOnFail(false, 'Specify --help for available options')
     .strict()
+    .wrap(120)
     .argv;
 
 // create runtime config from app package
@@ -135,4 +144,3 @@ flow.static = {
 
 // export config
 module.exports = flow;
-


### PR DESCRIPTION
I created argument names for port (`-p`, `--port`) and log level (`-l`, `--log-level`).
- now the only free argument is the path to the app which is free to be anywhere in the command line
- updated the README
